### PR TITLE
Fixes for HTML output

### DIFF
--- a/wolfSSL/Dockerfile
+++ b/wolfSSL/Dockerfile
@@ -25,14 +25,14 @@ COPY . .
 
 # Parallel build PDF
 FROM builder AS stage1
-WORKDIR /src/wolfssl
+WORKDIR /src/wolfssl/wolfSSL
 RUN make pdf
 
 # Parallel build HTML
 FROM builder AS stage2
-WORKDIR /src/wolfssl
+WORKDIR /src/wolfssl/wolfSSL
 RUN make html
 
 FROM scratch AS export-stage
-COPY --from=stage1 /src/wolfssl/wolfssl.pdf .
-COPY --from=stage2 /src/wolfssl/html ./html
+COPY --from=stage1 /src/wolfssl/wolfSSL/wolfssl.pdf .
+COPY --from=stage2 /src/wolfssl/wolfSSL/html ./html

--- a/wolfSSL/Makefile
+++ b/wolfSSL/Makefile
@@ -49,6 +49,7 @@ api: wolfssl-update
 # 3. Fix the titles of the header files markdown
 .PHONY: html-setup
 html-setup: api builddir $(SOURCES) $(APPENDIX)
+	@git submodule update --init
 	-cd ../mkdocs-material; patch -p1 < ../Custom-wolfSSL-theme.patch --ignore-whitespace -N
 	@cp src/*.png build/html/
 	@cp src/*.css build/html/
@@ -58,6 +59,7 @@ html-setup: api builddir $(SOURCES) $(APPENDIX)
 	@perl -i -pe "s/(?<=md\#function\-)(.*)(?=\))/\$$1=~s#-#_#gr/ge" build/html/group* build/html/*8h*
 	@perl -i -pe "s/\/group_/group_/g" build/html/group* build/html/*8h*
 	@perl -i -pe "s/dox_comments\/header_files\///" build/html/*8h*
+	@perl -i -pe "s/\#--/\#-/g" build/html/chapter*
 	@mv build/html/chapter01.md build/html/index.md
 
 html: html-setup
@@ -75,7 +77,7 @@ builddir:
 
 .PHONY: docker
 docker:
-	@DOCKER_BUILDKIT=1 docker build --target=export-stage -t doc_build --output=build .
+	@DOCKER_BUILDKIT=1 docker build --target=export-stage -t doc_build --output=build -f Dockerfile ..
 
 # Set input format to gfm to fix issues with converted API docs
 # Regexes:
@@ -101,10 +103,11 @@ pdf: api builddir $(SOURCES) $(APPENDIX)
 	@perl -i -pe "s/^\\\\//" build/pdf/group* build/pdf/*8h*
 	@perl -i -pe "s/\\\\par/par/g" build/pdf/group* build/pdf/*8h*
 	@perl -i -pe "s/group__.*.md//g" build/pdf/*8h* build/pdf/chapter*
-	@perl -i -pe "s/(ssl|wolfio|cryptocb|types|hash)_8h.md//g" build/pdf/chapter* 	
+	@perl -i -pe "s/(ssl|wolfio|cryptocb|types|hash)_8h.md//g" build/pdf/chapter*
+	@perl -i -pe "s/\#--/\#/g" build/pdf/chapter*
 	@cat build/pdf/group__CertManager.md build/pdf/group__Memory.md build/pdf/group__openSSL.md build/pdf/group__CertsKeys.md build/pdf/group__IO.md build/pdf/group__Setup.md build/pdf/group__Debug.md build/pdf/group__TLS.md >> build/pdf/appendix01.md
-	@cat build/pdf/group__ASN.md build/pdf/group__Base__Encoding.md build/pdf/group__Compression.md build/pdf/group__Error.md build/pdf/group__IoTSafe.md build/pdf/group__Keys.md build/pdf/group__Logging.md build/pdf/group__Math.md build/pdf/group__Random.md build/pdf/group__Signature.md build/pdf/group__wolfCrypt.md build/pdf/group__DES.md build/pdf/group__AES.md build/pdf/group__ARC4.md build/pdf/group__BLAKE2.md build/pdf/group__Camellia.md build/pdf/group__ChaCha.md build/pdf/group__ChaCha20Poly1305.md build/pdf/group__Crypto.md build/pdf/group__Curve25519.md build/pdf/group__Curve448.md build/pdf/group__DSA.md build/pdf/group__Diffie-Hellman.md build/pdf/group__ECC.md build/pdf/group__ED25519.md build/pdf/group__ED448.md >> build/pdf/appendix02.md
-	@cat build/pdf/aes_8h.md build/pdf/arc4_8h.md build/pdf/asn_8h.md build/pdf/asn__public_8h.md build/pdf/blake2_8h.md build/pdf/bn_8h.md build/pdf/camellia_8h.md build/pdf/chacha20__poly1305_8h.md build/pdf/chacha_8h.md build/pdf/coding_8h.md build/pdf/compress_8h.md build/pdf/cryptocb_8h.md build/pdf/curve25519_8h.md build/pdf/curve448_8h.md build/pdf/des3_8h.md build/pdf/dh_8h.md build/pdf/doxygen__groups_8h.md build/pdf/doxygen__pages_8h.md build/pdf/dsa_8h.md build/pdf/ecc_8h.md build/pdf/eccsi_8h.md build/pdf/ed25519_8h.md build/pdf/ed448_8h.md build/pdf/error-crypt_8h.md build/pdf/evp_8h.md build/pdf/hash_8h.md build/pdf/hmac_8h.md build/pdf/iotsafe_8h.md build/pdf/logging_8h.md build/pdf/md2_8h.md build/pdf/md4_8h.md build/pdf/md5_8h.md build/pdf/memory_8h.md build/pdf/pem_8h.md build/pdf/pkcs11_8h.md build/pdf/pkcs7_8h.md build/pdf/poly1305_8h.md build/pdf/pwdbased_8h.md build/pdf/random_8h.md build/pdf/ripemd_8h.md build/pdf/rsa_8h.md build/pdf/sakke_8h.md build/pdf/sha256_8h.md build/pdf/sha512_8h.md build/pdf/sha_8h.md build/pdf/signature_8h.md build/pdf/srp_8h.md build/pdf/ssl_8h.md build/pdf/tfm_8h.md build/pdf/types_8h.md build/pdf/wc__encrypt_8h.md build/pdf/wc__port_8h.md build/pdf/wolfio_8h.md >> build/pdf/appendix03.md
+	@cat build/pdf/group__ASN.md build/pdf/group__Base__Encoding.md build/pdf/group__Compression.md build/pdf/group__Error.md build/pdf/group__IoTSafe.md build/pdf/group__Keys.md build/pdf/group__Logging.md build/pdf/group__Math.md build/pdf/group__Random.md build/pdf/group__Signature.md build/pdf/group__wolfCrypt.md build/pdf/group__DES.md build/pdf/group__AES.md build/pdf/group__ARC4.md build/pdf/group__BLAKE2.md build/pdf/group__Camellia.md build/pdf/group__ChaCha.md build/pdf/group__ChaCha20Poly1305.md build/pdf/group__Crypto.md build/pdf/group__Curve25519.md build/pdf/group__Curve448.md build/pdf/group__DSA.md build/pdf/group__Diffie-Hellman.md build/pdf/group__ECC.md build/pdf/group__ED25519.md build/pdf/group__ED448.md build/pdf/group__HC128.md  build/pdf/group__IDEA.md  build/pdf/group__PSA.md  build/pdf/group__Rabbit.md  build/pdf/group__SipHash.md >> build/pdf/appendix02.md
+	@cat build/pdf/aes_8h.md build/pdf/arc4_8h.md build/pdf/asn_8h.md build/pdf/asn__public_8h.md build/pdf/blake2_8h.md build/pdf/bn_8h.md build/pdf/camellia_8h.md build/pdf/chacha20__poly1305_8h.md build/pdf/chacha_8h.md build/pdf/coding_8h.md build/pdf/compress_8h.md build/pdf/cryptocb_8h.md build/pdf/curve25519_8h.md build/pdf/curve448_8h.md build/pdf/des3_8h.md build/pdf/dh_8h.md build/pdf/doxygen__groups_8h.md build/pdf/doxygen__pages_8h.md build/pdf/dsa_8h.md build/pdf/ecc_8h.md build/pdf/eccsi_8h.md build/pdf/ed25519_8h.md build/pdf/ed448_8h.md build/pdf/error-crypt_8h.md build/pdf/evp_8h.md build/pdf/hash_8h.md build/pdf/hc128_8h.md build/pdf/hmac_8h.md build/pdf/idea_8h.md build/pdf/iotsafe_8h.md build/pdf/logging_8h.md build/pdf/md2_8h.md build/pdf/md4_8h.md build/pdf/md5_8h.md build/pdf/memory_8h.md build/pdf/pem_8h.md build/pdf/pkcs11_8h.md build/pdf/pkcs7_8h.md build/pdf/poly1305_8h.md build/pdf/psa_8h.md build/pdf/pwdbased_8h.md build/pdf/rabbit_8h.md build/pdf/random_8h.md build/pdf/ripemd_8h.md build/pdf/rsa_8h.md build/pdf/sakke_8h.md build/pdf/sha256_8h.md build/pdf/sha512_8h.md build/pdf/sha_8h.md build/pdf/signature_8h.md build/pdf/siphash_8h.md build/pdf/srp_8h.md build/pdf/ssl_8h.md build/pdf/tfm_8h.md build/pdf/types_8h.md build/pdf/wc__encrypt_8h.md build/pdf/wc__port_8h.md build/pdf/wolfio_8h.md >> build/pdf/appendix03.md
 	@cd build/pdf && pandoc \
 		-N \
         -s \

--- a/wolfSSL/mkdocs.yml
+++ b/wolfSSL/mkdocs.yml
@@ -65,7 +65,9 @@ nav:
         - "Setup SAKKE Key": group__SAKKE__Setup.md
         - "Operations on/with SAKKE RSK": group__SAKKE__RSK.md
         - "Operations using SAKKE Key": group__SAKKE__Operations.md
+      - "Algorithms - HC128": group__HC128.md
       - "Algorithms - HMAC": group__HMAC.md
+      - "Algorithms - IDEA": group__IDEA.md
       - "Algorithms - MD2": group__MD2.md
       - "Algorithms - MD4": group__MD4.md
       - "Algorithms - MD5": group__MD5.md
@@ -73,9 +75,12 @@ nav:
       - "Algorithms - PKCS7": group__PKCS7.md
       - "Algorithms - PKCS11": group__PKCS11.md
       - "Algorithms - Poly1305": group__Poly1305.md
+      - "Algorithms - PSA": group__PSA.md
+      - "Algorithms - Rabbit": group__Rabbit.md
       - "Algorithms - RIPEMD": group__RIPEMD.md
       - "Algorithms - RSA": group__RSA.md
       - "Algorithms - SHA 128/224/256/384/512": group__SHA.md
+      - "Algorithms - SipHash": group__SipHash.md
       - "Algorithms - SRP": group__SRP.md
     - "C. API Header Files":
       - aes_8h.md
@@ -104,7 +109,9 @@ nav:
       - error-crypt_8h.md
       - evp_8h.md
       - hash_8h.md
+      - hc128_8h.md
       - hmac_8h.md
+      - idea_8h.md
       - iotsafe_8h.md
       - logging_8h.md
       - md2_8h.md
@@ -115,7 +122,9 @@ nav:
       - pkcs11_8h.md
       - pkcs7_8h.md
       - poly1305_8h.md
+      - psa_8h.md
       - pwdbased_8h.md
+      - rabbit_8h.md
       - random_8h.md
       - ripemd_8h.md
       - rsa_8h.md
@@ -124,6 +133,7 @@ nav:
       - sha512_8h.md
       - sha_8h.md
       - signature_8h.md
+      - siphash_8h.md
       - srp_8h.md
       - ssl_8h.md
       - tfm_8h.md

--- a/wolfSSL/src/chapter02.md
+++ b/wolfSSL/src/chapter02.md
@@ -582,7 +582,7 @@ Enables ECC compressed key support.
 
 #### WOLFSSL_EXTRA_ALERTS
 
-Enables additional alerts to be sent during a TLS connection. This feature is also enabled automatically when [`--enable-opensslextra`](#enable-opensslextra) is used.
+Enables additional alerts to be sent during a TLS connection. This feature is also enabled automatically when [`--enable-opensslextra`](#--enable-opensslextra) is used.
 
 #### WOLFSSL_DEBUG_TLS
 
@@ -1415,7 +1415,7 @@ Enabling AES-GCM will add these cipher suites to wolfSSL.  wolfSSL offers four d
 
 ### `--disable-aescbc`
 
-Used to with [`--disable-aescbc`](#disable-aescbc) to compile out AES-CBC
+Used to with [`--disable-aescbc`](#--disable-aescbc) to compile out AES-CBC
 
 AES-GCM will enable Counter with CBC-MAC Mode with 8‑byte authentication (CCM-8) for AES.
 
@@ -1895,11 +1895,11 @@ Path to USER\_CRYPTO install (default `/usr/local`).
 
 ### `--enable-rsavfy`
 
-Enables RSA verify only support (**note** requires [`--enable-cryptonly`](#enable-cryptonly))
+Enables RSA verify only support (**note** requires [`--enable-cryptonly`](#--enable-cryptonly))
 
 ### `--enable-rsapub`
 
-Default value: Enabled RSA public key only support (**note** requires [`--enable-cryptonly`](#enable-cryptonly))
+Default value: Enabled RSA public key only support (**note** requires [`--enable-cryptonly`](#--enable-cryptonly))
 
 ### `--enable-armasm`
 
@@ -1915,7 +1915,7 @@ Disable TLS 1.2 support
 
 Enable TLS 1.3 support
 
-This build option can be combined with [`--disable-tlsv12`](#disable-tlsv12) and [`--disable-oldtls`](#disable-oldtlx) to produce a wolfSSL build that is only TLS 1.3.
+This build option can be combined with [`--disable-tlsv12`](#--disable-tlsv12) and [`--disable-oldtls`](#--disable-oldtlx) to produce a wolfSSL build that is only TLS 1.3.
 
 ### `--enable-all`
 
@@ -1929,7 +1929,7 @@ Enables AES-XTS mode
 
 Enables ASIO.
 
-Requires that the options [`--enable-opensslextra`](#enable-opensslextra) and [`--enable-opensslall`](#enable-opensslall) be enabled when configuring wolfSSL. If these two options are not enabled, then the autoconf tool will automatically enable these options to enable ASIO when configuring wolfSSL.
+Requires that the options [`--enable-opensslextra`](#--enable-opensslextra) and [`--enable-opensslall`](#--enable-opensslall) be enabled when configuring wolfSSL. If these two options are not enabled, then the autoconf tool will automatically enable these options to enable ASIO when configuring wolfSSL.
 
 ### `--enable-qt`
 
@@ -1951,7 +1951,7 @@ Enables Apache httpd support
 
 Enables use of Linux module AF\_ALG for hardware accleration. Additional Xilinx use with `=xilinx`, `=xilinx-rsa`, `=xilinx-aes`, `=xilinx-sha3`
 
-Is similar to [`--enable-devcrypto`](#enable-devcrypto) in that it leverages a Linux kernel module (AF\_ALG) for offloading crypto operations. On some hardware the module has performance accelerations available through the Linux crypto drivers. In the case of Petalinux with Xilinx the flag `--enable-afalg=xilinx` can be used to tell wolfSSL to use the Xilinx interface for AF\_ALG.
+Is similar to [`--enable-devcrypto`](#--enable-devcrypto) in that it leverages a Linux kernel module (AF\_ALG) for offloading crypto operations. On some hardware the module has performance accelerations available through the Linux crypto drivers. In the case of Petalinux with Xilinx the flag `--enable-afalg=xilinx` can be used to tell wolfSSL to use the Xilinx interface for AF\_ALG.
 
 ### `--enable-devcrypto`
 

--- a/wolfSSL/src/chapter04.md
+++ b/wolfSSL/src/chapter04.md
@@ -66,7 +66,7 @@ The TLS protocol was designed to provide a secure transport channel across a **r
 
 Many people believe the difference between TLS and DTLS is the same as TCP vs. UDP. This is incorrect.  UDP has the benefit of having no handshake, no tear-down, and no delay in the middle if something gets lost (compared with TCP).  DTLS on the other hand, has an extended SSL handshake and tear-down and must implement TCP-like behavior for the handshake.  In essence, DTLS reverses the benefits that are offered by UDP in exchange for a secure connection.
 
-DTLS can be enabled when building wolfSSL by using the [`--enable-dtls`](chapter02.md#enable-dtls) build option.
+DTLS can be enabled when building wolfSSL by using the [`--enable-dtls`](chapter02.md#--enable-dtls) build option.
 
 ### LwIP (Lightweight Internet Protocol)
 
@@ -288,7 +288,7 @@ wolfSSL supports AEAD suites, including AES-GCM, AES-CCM, and CHACHA-POLY1305. T
 
 ### Block and Stream Ciphers
 
-wolfSSL supports the **AES**, **DES**, **3DES**, and **Camellia** block ciphers and the **RC4**, and **CHACHA20 **stream ciphers. AES, DES, 3DES and RC4 are enabled by default.  Camellia, and ChaCha20 can be enabled when building wolfSSL (with the [`--enable-camellia`](chapter02.md#enable-camellia), and [`--disable-chacha`](chapter02.md#disable-chacha) build options, respectively). The default mode of AES is CBC mode.  To enable GCM or CCM mode with AES, use the [`--enable-aesgcm`](chapter02.md#enable-aesgcm) and [`--enable-aesccm`](chapter02.md#enable-aesccm) build options.  Please see the examples for usage and the [wolfCrypt Usage Reference](chapter10.md#wolfcrypt-usage-reference) for specific usage information.
+wolfSSL supports the **AES**, **DES**, **3DES**, and **Camellia** block ciphers and the **RC4**, and **CHACHA20 **stream ciphers. AES, DES, 3DES and RC4 are enabled by default.  Camellia, and ChaCha20 can be enabled when building wolfSSL (with the [`--enable-camellia`](chapter02.md#--enable-camellia), and [`--disable-chacha`](chapter02.md#--disable-chacha) build options, respectively). The default mode of AES is CBC mode.  To enable GCM or CCM mode with AES, use the [`--enable-aesgcm`](chapter02.md#--enable-aesgcm) and [`--enable-aesccm`](chapter02.md#--enable-aesccm) build options.  Please see the examples for usage and the [wolfCrypt Usage Reference](chapter10.md#wolfcrypt-usage-reference) for specific usage information.
 
 While SSL uses RC4 as the default stream cipher, it has been obsoleted due to compromise. Recently wolfSSL added ChaCha20. While RC4 is about 11% more performant than ChaCha, RC4 is generally considered less secure than ChaCha. ChaCha can put up very nice times of it’s own with added security as a tradeoff.
 
@@ -360,7 +360,7 @@ int PKCS12_PBKDF(byte* output, const byte* passwd, int pLen,
 
 `output` contains the derived key, `passwd` holds the user password of length `pLen`, `salt` holds the salt input of length `sLen`, `iterations` is the number of iterations to perform, `kLen` is the desired derived key length, and `hashType` is the hash to use (which can be MD5, SHA1, or SHA2).
 
-If you are using `./configure` to build wolfssl, the way to enable this functionality is to use the option [`--enable-pwdbased`](chapter02.md#enable-pwdbased)
+If you are using `./configure` to build wolfssl, the way to enable this functionality is to use the option [`--enable-pwdbased`](chapter02.md#--enable-pwdbased)
 
 A full example can be found in `<wolfSSL Root>/wolfcrypt/test.c`. More information can be found on PKCS #5, PBKDF1, and PBKDF2 from the following specifications:
 
@@ -376,7 +376,7 @@ PKCS#8:  [https://tools.ietf.org/html/rfc5208](https://tools.ietf.org/html/rfc52
 
 #### PKCS #7
 
-PKCS #7 is designed to transfer bundles of data whether is an enveloped certificate or unencrypted but signed string of data. The functionality is turned on by using the enable option ([`--enable-pkcs7`](chapter02.md#enable-pkcs7)) or by using the macro `HAVE_PKCS7`. Note that degenerate cases are allowed by default as per the RFC having an empty set of signers. To toggle allowing degenerate cases on and off the function `wc_PKCS7_AllowDegenerate()` can be called.
+PKCS #7 is designed to transfer bundles of data whether is an enveloped certificate or unencrypted but signed string of data. The functionality is turned on by using the enable option ([`--enable-pkcs7`](chapter02.md#--enable-pkcs7)) or by using the macro `HAVE_PKCS7`. Note that degenerate cases are allowed by default as per the RFC having an empty set of signers. To toggle allowing degenerate cases on and off the function `wc_PKCS7_AllowDegenerate()` can be called.
 
 Supported features include:
 
@@ -440,7 +440,7 @@ Essentially, Intel and AMD have added AES instructions at the chip level that pe
 
 We have added the functionality to wolfSSL to allow it to call  the instructions directly from the chip, instead of running the algorithm in software. This means that when you’re running wolfSSL on a chipset that supports AES-NI, you can run your AES crypto 5-10 times faster!
 
-If you are running on an AES-NI supported chipset, enable AES-NI with the [`--enable-aesni` build option](chapter02.md#enable-aesni).  To build wolfSSL with AES-NI, GCC 4.4.3 or later is required to make use of the assembly code.  wolfSSL supports the ASM instructions on AMD processors using the same build options.
+If you are running on an AES-NI supported chipset, enable AES-NI with the [`--enable-aesni` build option](chapter02.md#--enable-aesni).  To build wolfSSL with AES-NI, GCC 4.4.3 or later is required to make use of the assembly code.  wolfSSL supports the ASM instructions on AMD processors using the same build options.
 
 References and further reading on AES-NI, ordered from general to specific, are listed below.  For information about performance gains with AES-NI, please see the third link to the Intel Software Network page.
 
@@ -466,7 +466,7 @@ wolfSSL has support for Marvell (previously Cavium) NITROX (<https://www.marvell
 ./configure --with-cavium=/home/user/cavium/software
 ```
 
-Where the [`--with-cavium=**`](chapter02.md#with-cavium) option is pointing to your licensed cavium/software directory.  Since Cavium doesn't build a library wolfSSL pulls in the `cavium_common.o` file which gives a libtool warning about the portability of this.  Also, if you're using the github source tree you'll need to remove the `-Wredundant-decls` warning from the generated Makefile because the cavium headers don't conform to this warning.
+Where the [`--with-cavium=**`](chapter02.md#--with-cavium) option is pointing to your licensed cavium/software directory.  Since Cavium doesn't build a library wolfSSL pulls in the `cavium_common.o` file which gives a libtool warning about the portability of this.  Also, if you're using the github source tree you'll need to remove the `-Wredundant-decls` warning from the generated Makefile because the cavium headers don't conform to this warning.
 
 Currently wolfSSL supports Cavium RNG, AES, 3DES, RC4, HMAC, and RSA directly at the crypto layer.  Support at the SSL level is partial and currently just does AES, 3DES, and RC4.  RSA and HMAC are slower until the Cavium calls can be utilized in non-blocking mode.  The example client turns on cavium support as does the crypto test and benchmark.  Please see the `HAVE_CAVIUM` define.
 
@@ -485,7 +485,7 @@ Beginning with the wolfSSL 1.5.0 release, wolfSSL has included a build option al
 * Monitoring network usage and data in motion
 * Debugging client/server communications
 
-To enable sniffer support, build wolfSSL with the [`--enable-sniffer`](chapter02.md#enable-sniffer) option on \*nix or use the **vcproj** files on Windows. You will need to have **pcap** installed on \*nix or **WinPcap** on Windows. The main sniffer functions which can be found in `sniffer.h` are listed below with a short description of each:
+To enable sniffer support, build wolfSSL with the [`--enable-sniffer`](chapter02.md#--enable-sniffer) option on \*nix or use the **vcproj** files on Windows. You will need to have **pcap** installed on \*nix or **WinPcap** on Windows. The main sniffer functions which can be found in `sniffer.h` are listed below with a short description of each:
 
 * `ssl_SetPrivateKey` - Sets the private key for a specific server and port.
 * `ssl_SetNamedPrivateKey` - Sets the private key for a specific server, port and domain name.
@@ -675,7 +675,7 @@ make
 sudo make install
 ```
 
-The included example in wolfSSL requires the use of IPP, which will need to be installed before the project can be built. Though even if not having IPP libraries to build the example it is intended to provide users with an example of file name choice and API interface. Once having made and installed both the library libusercrypto and header files, making wolfSSL use the crypto module does not require any extra steps. Simply using the configure flag [`--with-user-crypto`](chapter02.md#with-user-crypto) will map all function calls from the typical wolfSSL crypto to the user crypto module.
+The included example in wolfSSL requires the use of IPP, which will need to be installed before the project can be built. Though even if not having IPP libraries to build the example it is intended to provide users with an example of file name choice and API interface. Once having made and installed both the library libusercrypto and header files, making wolfSSL use the crypto module does not require any extra steps. Simply using the configure flag [`--with-user-crypto`](chapter02.md#--with-user-crypto) will map all function calls from the typical wolfSSL crypto to the user crypto module.
 
 Memory allocations, if using wolfSSL’s XMALLOC, should be tagged with `DYNAMIC_TYPE_USER_CRYPTO`. Allowing for analyzing memory allocations used by the module.
 
@@ -687,7 +687,7 @@ wolfSSL provides the function “ConstantCompare” which guarantees constant ti
 
 The wolfSSL ECC implementation has the define `ECC_TIMING_RESISTANT` to enable timing-resistance in the ECC algorithm. Similarly the define `TFM_TIMING_RESISTANT` is provided in the fast math libraries for RSA algorithm timing-resistance. The function exptmod uses the timing resistant Montgomery ladder.
 
-See also: [`--disable-harden`](chapter02.md#disable-harden)
+See also: [`--disable-harden`](chapter02.md#--disable-harden)
 
 Timing resistance and cache resistance defines enabled with `--enable-harden`:
 

--- a/wolfSSL/src/chapter06.md
+++ b/wolfSSL/src/chapter06.md
@@ -184,4 +184,4 @@ These contexts may be pointers to any user-specified context, which will then in
 
 Example callbacks can be found in `wolfssl/test.h`, under `myEccSign()`, `myEccVerify()`, `myEccSharedSecret()`, `myRsaSign()`, `myRsaVerify()`, `myRsaEnc()`, and `myRsaDec()`.  Usage can be seen in the wolfSSL example client (`examples/client/client.c`), when using the `-P` command line option.
 
-To use Atomic Record Layer callbacks, wolfSSL needs to be compiled using the [`--enable-pkcallbacks`](chapter02.md#enable-pkcallbacks) configure option, or by defining the `HAVE_PK_CALLBACKS` preprocessor flag.
+To use Atomic Record Layer callbacks, wolfSSL needs to be compiled using the [`--enable-pkcallbacks`](chapter02.md#--enable-pkcallbacks) configure option, or by defining the `HAVE_PK_CALLBACKS` preprocessor flag.

--- a/wolfSSL/src/chapter13.md
+++ b/wolfSSL/src/chapter13.md
@@ -10,7 +10,7 @@ Our test beds for OpenSSL compatibility are stunnel and Lighttpd, which means th
 
 Building wolfSSL With Compatibility Layer:
 
-1. Enable with ([`--enable-opensslextra`](chapter02.md#enable-opensslextra)) or by defining the macro `OPENSSL_EXTRA`.
+1. Enable with ([`--enable-opensslextra`](chapter02.md#--enable-opensslextra)) or by defining the macro `OPENSSL_EXTRA`.
 
     ```sh
     ./configure --enable-opensslextra


### PR DESCRIPTION
Several fixes mostly for HTML output. These include:

1. Fixing the Docker build so that it works with the MKDocs theme
2. Run the git submodule update during build
3. Fix internal links that start with "--" (for PDF the "--" needs to go
   away, for HTML it needs to be truncated to "-")
4. Add newer missing Doxygen files