### PR TITLE
Espressif WOLFSSL_ESP8266 setting for ESP8266

### DIFF
--- a/wolfSSL/src/chapter04.md
+++ b/wolfSSL/src/chapter04.md
@@ -478,7 +478,8 @@ For necessary defines, see the `WOLFSSL_ESPWROOM32` define in `settings.h`. The 
 
 ### ESP8266
 
-Unlike the ESP32, there's no hardware-based cryptography available for the ESP8266. See the `WOLFSSL_ESP8266` define in `settings.h`.
+Unlike the ESP32, there's no hardware-based cryptography available for the ESP8266. See the `WOLFSSL_ESP8266` define in `user_settings.h`
+or use `./configure CFLAGS="-DWOLFSSL_ESP8266"` to compile for the embedded ESP8266 target.
 
 ## SSL Inspection (Sniffer)
 


### PR DESCRIPTION
Add info regarding `WOLFSSL_ESP8266` define in `settings.h`

See https://github.com/wolfSSL/wolfssl/pull/5077