### PR TITLE
Add clarification for file names and update example instructions

### DIFF
--- a/wolfSSL-JNI/src/chapter03.md
+++ b/wolfSSL-JNI/src/chapter03.md
@@ -13,7 +13,7 @@ JNI C source files into a shared library for either Unix/Linux or Mac OSX.
 This script tries to auto-detect between OSX (Darwin) and Linux to set up
 include paths and shared library extension type. This script directly calls gcc
 on the JNI C source files, producing `./lib/libwolfssljni.so`,
-`./lib/libwolfssljni.dylib`, or `./lib/wolfssljni.dylib`.
+`./lib/libwolfssljni.dylib`, or `./lib/libwolfssljni.jnilib`.
 
 ```
 $ ./java.sh

--- a/wolfSSL-JNI/src/chapter03.md
+++ b/wolfSSL-JNI/src/chapter03.md
@@ -12,8 +12,8 @@ The `java.sh` script in the root package directory is used to compile the native
 JNI C source files into a shared library for either Unix/Linux or Mac OSX.
 This script tries to auto-detect between OSX (Darwin) and Linux to set up
 include paths and shared library extension type. This script directly calls gcc
-on the JNI C source files, producing `./lib/libwolfssljni.so`,
-`./lib/libwolfssljni.dylib`, or `./lib/libwolfssljni.jnilib`.
+on the JNI C source files, producing `./lib/libwolfssljni.so` or
+`./lib/libwolfssljni.jnilib`.
 
 ```
 $ ./java.sh

--- a/wolfSSL-JNI/src/chapter03.md
+++ b/wolfSSL-JNI/src/chapter03.md
@@ -12,8 +12,8 @@ The `java.sh` script in the root package directory is used to compile the native
 JNI C source files into a shared library for either Unix/Linux or Mac OSX.
 This script tries to auto-detect between OSX (Darwin) and Linux to set up
 include paths and shared library extension type. This script directly calls gcc
-on the JNI C source files, producing `./lib/libwolfssljni.so` or
-`./lib/libwolfssljni.dylib`.
+on the JNI C source files, producing `./lib/libwolfssljni.so`,
+`./lib/libwolfssljni.dylib`, or `./lib/wolfssljni.dylib`.
 
 ```
 $ ./java.sh

--- a/wolfSSL-JNI/src/chapter04.md
+++ b/wolfSSL-JNI/src/chapter04.md
@@ -54,7 +54,7 @@ for (Provider prov:providers) {
 
 To install the wolfJSSE provider at the system/OS level, copy the `wolfssl.jar`
 and/or `wolfssl-jsse.jar` into the correct Java installation directory for your
-OS and verify the `libwolfssljni.so` or `libwolfssljni.jnilib` shared library 
+OS and verify the `libwolfssljni.so` or `libwolfssljni.jnilib` shared library
 is on your library search path.
 
 Add the JAR files (`wolfssl.jar`, `wolfssl-jsse.jar`) and shared library

--- a/wolfSSL-JNI/src/chapter04.md
+++ b/wolfSSL-JNI/src/chapter04.md
@@ -54,8 +54,8 @@ for (Provider prov:providers) {
 
 To install the wolfJSSE provider at the system/OS level, copy the `wolfssl.jar`
 and/or `wolfssl-jsse.jar` into the correct Java installation directory for your
-OS and verify the `libwolfssljni.so` or `libwolfssljni.dylib` shared library
-is on your library search path.
+OS and verify the `libwolfssljni.so`, `libwolfssljni.dylib`, or
+`libwolfssljni.jnilib` shared library is on your library search path.
 
 Add the JAR files (`wolfssl.jar`, `wolfssl-jsse.jar`) and shared library
 (`libwolfssljni.so`) to the following directory:

--- a/wolfSSL-JNI/src/chapter04.md
+++ b/wolfSSL-JNI/src/chapter04.md
@@ -54,8 +54,8 @@ for (Provider prov:providers) {
 
 To install the wolfJSSE provider at the system/OS level, copy the `wolfssl.jar`
 and/or `wolfssl-jsse.jar` into the correct Java installation directory for your
-OS and verify the `libwolfssljni.so`, `libwolfssljni.dylib`, or
-`libwolfssljni.jnilib` shared library is on your library search path.
+OS and verify the `libwolfssljni.so` or `libwolfssljni.jnilib` shared library 
+is on your library search path.
 
 Add the JAR files (`wolfssl.jar`, `wolfssl-jsse.jar`) and shared library
 (`libwolfssljni.so`) to the following directory:

--- a/wolfSSL-JNI/src/chapter05.md
+++ b/wolfSSL-JNI/src/chapter05.md
@@ -38,7 +38,9 @@ classes.
 
 Once wolfSSL JNI and wolfJSSE have been compiled, there are two JAR files and
 one native shared library that have been generated. These are located in the
-`./lib` directory.
+`./lib` directory. The native shared library could also be named
+`libwolfssljni.dylib` or `libwolfssljni.jnilib` depending on the operating
+system.
 
 ```
 lib/

--- a/wolfSSL-JNI/src/chapter05.md
+++ b/wolfSSL-JNI/src/chapter05.md
@@ -39,8 +39,7 @@ classes.
 Once wolfSSL JNI and wolfJSSE have been compiled, there are two JAR files and
 one native shared library that have been generated. These are located in the
 `./lib` directory. The native shared library could also be named
-`libwolfssljni.dylib` or `libwolfssljni.jnilib` depending on the operating
-system.
+`libwolfssljni.jnilib` depending on the operating system.
 
 ```
 lib/

--- a/wolfSSL-JNI/src/chapter08.md
+++ b/wolfSSL-JNI/src/chapter08.md
@@ -99,7 +99,7 @@ Example usage for connecting to the wolfSSL example server is:
 
 ```
 $ ./examples/provider/ClientSSLSocket.sh 127.0.0.1 11111 \
-  ./examples/provider/client.jks ./examples/provider/client.jks
+  ./examples/provider/client.jks ./examples/provider/ca-server.jks
 ```
 
 The password for client.jks is: "wolfSSL test"


### PR DESCRIPTION
Add clarification that on some operating systems the libwolfssljni.so file that is created during compilation could be named libwolfssljni.jnilib. Additionally, update example instructions for ClientSSLSocket.java example so that people can run the example by following the instructions.