### PR TITLE
Fix error in System Installation Instructions

### DIFF
--- a/wolfSSL-JNI/src/chapter04.md
+++ b/wolfSSL-JNI/src/chapter04.md
@@ -90,7 +90,7 @@ numbers on the other providers listed in the java.security file. The highest
 priority is `1`.
 
 ```
-security.provider.1=com.wolfssl.provider.jce.WolfSSLProvider
+security.provider.1=com.wolfssl.provider.jsse.WolfSSLProvider
 ```
 
 ###  Android OSP (AOSP)

--- a/wolfSSL-JNI/src/chapter04.md
+++ b/wolfSSL-JNI/src/chapter04.md
@@ -73,7 +73,7 @@ On Ubuntu with OpenJDK this path may be similar to:
 Next, add an entry to the `java.security` file similar to the following:
 
 ```
-security.provider.N=com.wolfssl.provider.jce.WolfSSLProvider
+security.provider.N=com.wolfssl.provider.jsse.WolfSSLProvider
 ```
 
 The java.security file will be located at:


### PR DESCRIPTION
Change line that should be added to java.security from "jce" to "jsse".