### PR TITLE
add WOLFSSL_APPLE_NATIVE_CERT_VALIDATION and WOLFSSL_SYS_CA_CERTS

### DIFF
--- a/wolfSSL/src/chapter02.md
+++ b/wolfSSL/src/chapter02.md
@@ -596,6 +596,14 @@ Will choose a hash algorithm that matches the ephemeral ECDHE key size or the ne
 
 Allows CA's to be presented by peer, but not part of a valid chain. Default wolfSSL behavior is to require validation of all presented peer certificates. This also allows loading intermediate CA's as trusted and ignoring no signer failures for CA's up the chain to root. The alternate certificate chain mode only requires that the peer certificate validate to a trusted CA.
 
+#### WOLFSSL_SYS_CA_CERTS
+
+Allows wolfSSL to use trusted system CA certificates for verification when [`wolfSSL_CTX_load_system_CA_certs()`](group__CertsKeys.html#function-wolfssl_ctx_load_system_ca_certs) is called, either by loading them into wolfSSL certificate manager, or by invoking system authentication APIs. See [`wolfSSL_CTX_load_system_CA_certs()`](group__CertsKeys.html#function-wolfssl_ctx_load_system_ca_certs) for more details. This preprocessor macro is automatically set by the `--enable-sys-ca-certs` configure option.
+
+#### WOLFSSL_APPLE_NATIVE_CERT_VERIFICATION
+
+Enables the use of Apple's native trust APIs when authenticating TLS peer certificates. Requires [WOLFSSL_SYS_CA_CERTS](#WOLFSSL_SYS_CA_CERTS) to be defined. This macro does not need to be set by the user if building with `configure` or `CMake` on iOS or other apple devices, but should be explicitly set on MacOS if you wish to use the native verification methods.
+
 #### WOLFSSL_CUSTOM_CURVES
 
 Allow non-standard curves. Includes the curve "a" variable in calculation. Additional curve types can be enabled using [`HAVE_ECC_SECPR2`](#have_ecc_secpr2), [`HAVE_ECC_SECPR3`](#have_ecc_secpr3), [`HAVE_ECC_BRAINPOOL`](#have_ecc_brainpool) and [`HAVE_ECC_KOBLITZ`](#have_ecc_koblitz).
@@ -2058,6 +2066,9 @@ Use of the WOLF_CRYPTO_CB_ONLY_* options requires disabling the examples. See [`
 ### `--enable-reproducible-build`
 
 Suppresses the binary jitter (timestamps and other non-functional metadata) to allow generation of bitwise-identical binary packages with identical hashes.
+
+### `--enable-sys-ca-certs`
+Allows wolfSSL to use trusted system CA certificates for verification when [`wolfSSL_CTX_load_system_CA_certs()`](group__CertsKeys.html#function-wolfssl_ctx_load_system_ca_certs) is called, either by loading them into wolfSSL certificate manager, or by invoking system authentication APIs. See [`wolfSSL_CTX_load_system_CA_certs()`](group__CertsKeys.html#function-wolfssl_ctx_load_system_ca_certs) for more details.
 
 ## Special Math Optimization Flags
 


### PR DESCRIPTION
Adds documentation of new `WOLFSSL_APPLE_NATIVE_CERT_VALIDATION` macro, as well as improve documentation for existing system CA cert option (`--enable-sys-ca-certs` and `WOLFSSL_SYS_CA_CERTS`)