### PR TITLE
wolfHSM: only document client and server headers

### DIFF
--- a/wolfHSM/Doxyfile
+++ b/wolfHSM/Doxyfile
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "wolfTPM2"
+PROJECT_NAME           = "wolfHSM"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -865,7 +865,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = README.md wolfhsm
+INPUT                  = README.md wolfhsm/wh_client.h wolfhsm/wh_server.h
 
 
 # This tag can be used to specify the character encoding of the source files


### PR DESCRIPTION
Only documents public client+server API functions. Tested locally and seems to render fine.