### PR TITLE
Update Self-Signed Certificate Error Code

### DIFF
--- a/wolfSSL/src-ja/appendix06.md
+++ b/wolfSSL/src-ja/appendix06.md
@@ -324,7 +324,7 @@ WolfCryptエラーコードは`wolfssl/wolfcrypt/error.h`にあります。
 |`WC_PKCS7_WANT_READ_E` |-270 |PKCS7ストリーム操作では、より多くの入力が必要です|
 |`CRYPTOCB_UNAVAILABLE` |-271 |Crypto Callbackが利用できません|
 |`PKCS7_SIGNEEDS_CHECK` |-272 |発信者によって検証された署名のニーズ|
-|`ASN_SELF_SIGNED_E` |-273 |ASN自己署名証明書エラー|
+|`ASN_SELF_SIGNED_E` |-275 |ASN自己署名証明書エラー|
 |`MIN_CODE_E` |-300 |エラー-101- -299 |
 
 

--- a/wolfSSL/src/appendix06.md
+++ b/wolfSSL/src/appendix06.md
@@ -307,7 +307,7 @@ wolfCrypt error codes can be found in `wolfssl/wolfcrypt/error.h`.
 | `WC_PKCS7_WANT_READ_E` | -270 | PKCS7 stream operation wants more input |
 | `CRYPTOCB_UNAVAILABLE` | -271 | Crypto callback unavailable |
 | `PKCS7_SIGNEEDS_CHECK` | -272 | Signature needs verified by caller |
-| `ASN_SELF_SIGNED_E` | -273 | ASN self-signed certificate error |
+| `ASN_SELF_SIGNED_E` | -275 | ASN self-signed certificate error |
 | `MIN_CODE_E` | -300 | errors -101 -  -299 |
 
 ## Common Error Codes and their Solution


### PR DESCRIPTION
The documented error code for `ASN_SELF_SIGNED_E` is inconsistent with wolfssl/wolfcrypt/error-crypt.h in the wolfssl repository. Update the documentation so that the error code matches wolfssl/wolfcrypt/error-crypt.h.