### PR TITLE
Add documentation for new flag WOLFSSL_GET_CIPHER_BYTES

### DIFF
--- a/wolfSSL/src/chapter02.md
+++ b/wolfSSL/src/chapter02.md
@@ -1507,6 +1507,9 @@ Embedded callbacks require large static buffers; make sure it gives the option t
 
 This is the wolfSSL version string populated for release bundles or when `./configure` is run. There is also a 32-bit HEX version of this in `LIBWOLFSSL_VERSION_HEX`. These come from wolfssl/version.h.
 
+#### WOLFSSL_GET_CIPHER_BYTES
+
+Enables support for retrieving byte array representation of enabled ciphersuites.
 
 ### Customizing or Porting wolfSSL
 


### PR DESCRIPTION
Adds documentation for new flag added by PR https://github.com/wolfSSL/wolfssl/pull/7731