### PR TITLE
Fix documentation title

### DIFF
--- a/wolfSSL/Doxyfile
+++ b/wolfSSL/Doxyfile
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           =
+PROJECT_NAME           = wolfSSL
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/wolfSSL/Doxyfile-ja
+++ b/wolfSSL/Doxyfile-ja
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           =
+PROJECT_NAME           = wolfSSL
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version


### PR DESCRIPTION
This fixes the title in https://www.wolfssl.com/doxygen/ so that it doesn't say "My Project".