### PR TITLE
Updating need for --enable-openssh for wolfEngine

### DIFF
--- a/wolfEngine/src/chapter03.md
+++ b/wolfEngine/src/chapter03.md
@@ -202,6 +202,7 @@ By default, wolfEngine only builds a shared library, with building of a static l
 | --enable-p384 | Enabled | Enable EC Curve P-384 |
 | --enable-p521 | Enabled | Enable EC Curve P-521 |
 | --with-openssl=DIR |   | OpenSSL installation location to link against. If not set, use the system default library and include paths. |
+| --enable-openssh | **Disabled** | Enables use with openssh |
 
 ## Build Defines
 

--- a/wolfEngine/src/chapter10.md
+++ b/wolfEngine/src/chapter10.md
@@ -23,6 +23,8 @@ stunnel has been tested with wolfEngine. Notes coming soon.
 
 ## OpenSSH
 
+To use wolfEngine with OpenSSH you will need to add `--enable-openssh` to the `./configure` line of wolfEngine.
+
 OpenSSH needs to be compiled with OpenSSL engine support using the `--with-ssl-engine` configure option. If needed, `--with-ssl-dir=DIR` can also be used to specify the installation location of the OpenSSL library being used:
 ```
 $ cd openssh


### PR DESCRIPTION
Found that to use `wolfEngine` with `openSSH` via `openSSL` you need `--enable-openssh` when doing `./configure` during the `wolfEngine` setup, if this is not specified it will lead to a permissions error when trying to open things such as `/dev/random`.

There seems to be no documentation on this requirement.

This [line](https://github.com/wolfSSL/wolfEngine/blob/178f4dc3c1e1577054d7be05da3ce440e82d7ec0/configure.ac#L132) here is where its at in the configure for wolfEngine