### PR TITLE
fixed error in WolfSSL chapter11.md

### DIFF
--- a/wolfSSL/src/chapter11.md
+++ b/wolfSSL/src/chapter11.md
@@ -15,7 +15,7 @@ This tutorial assumes that the reader is comfortable with editing and compiling 
 
 ## Quick Summary of SSL/TLS
 
-**TLS** (Transport Layer Security) and **SSL** (Secure Sockets Layer) are cryptographic protocols that allow for secure communication across a number of different transport protocols.  The primary transport protocol used is TCP/IP. The most recent version of SSL/TLS is TLS 1.3. wolfSSL supports SSL 3.0, TLS 1.0, 1.1, 1.2, 1.3 in addition to DTLS 1.0 and 1.2.
+**TLS** (Transport Layer Security) and **SSL** (Secure Sockets Layer) are cryptographic protocols that allow for secure communication across a number of different transport protocols.  The primary transport protocol used is TCP/IP. The most recent version of SSL/TLS is TLS 1.3. wolfSSL supports SSL 3.0, TLS 1.0, 1.1, 1.2, 1.3 in addition to DTLS 1.0, 1.2, and 1.3
 
 SSL and TLS sit between the Transport and Application layers of the OSI model, where any number of protocols (including TCP/IP, Bluetooth, etc.) may act as the underlying transport medium. Application protocols are layered on top of SSL and can include protocols such as HTTP, FTP, and SMTP. A diagram of how SSL fits into the OSI model, as well as a simple diagram of the SSL handshake process can be found in Appendix A.
 


### PR DESCRIPTION
Previously a paragraph stated that WolfSSL supports DTLS 1.0 and 1.2. This has been updated to include DTLS 1.3 as well.