### PR TITLE
Added clarification for wolfSSH ch.3 wolfscp example and fixed a command in wolfMQTT ch.2

### DIFF
--- a/wolfMQTT/src/chapter02.md
+++ b/wolfMQTT/src/chapter02.md
@@ -4,7 +4,7 @@ wolfMQTT was written with portability in mind, and should generally be easy to b
 
 When using the autoconf / automake system to build, wolfMQTT uses a single Makefile to build all parts and examples of the library, which is both simpler and faster than using Makefiles recursively. If using the TLS features or the Firmware/Azure IoT Hub examples you’ll need to have wolfSSL installed. For wolfSSL and wolfMQTT we recommend using config options below
 ```
-./configure  --enable-ecc  --enable-supportedcurves  --enable-base64encode. 
+./configure  --enable-ecc  --enable-supportedcurves  --enable-base64encode
 ```
 For wolfSSL use `make && sudo make install`. If you get an error locating the libwolfssl.so, run `sudo ldconfig` from the wolfSSL directory.
 

--- a/wolfSSH/src/chapter03.md
+++ b/wolfSSH/src/chapter03.md
@@ -136,7 +136,8 @@ The portfwd tool accepts the following command line options:
 ### wolfSSH scpclient
 
 The scpclient, wolfscp, establishes a connection to an SSH server and copies
-the specified files from or to the local machine.
+the specified files from or to the local machine. When using the wolfSSH
+example, absolute paths must be used, and directories must end with a `/`.
 
 The scpclient tool accepts the following command line options:
 ```


### PR DESCRIPTION
In wolfSSH added clarity to wolfSSH scpclient to properly use the example for sending files to and from server. In wolfMQTT fixed a command that had a random '.' at the end of it.