### PR TITLE
wolfHSM fixed/added API reference and fixed pdf build

### DIFF
--- a/wolfHSM/Doxyfile
+++ b/wolfHSM/Doxyfile
@@ -867,6 +867,7 @@ WARN_LOGFILE           =
 
 INPUT                  = README.md \
                          wolfhsm/wh_client.h \
+                         wolfhsm/wh_client_crypto.h \
                          wolfhsm/wh_server.h
 
 # This tag can be used to specify the character encoding of the source files
@@ -983,7 +984,8 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS        = whServer* WH_SERVER_* wh_server_* \
+                         whClient* WH_CLIENT_* wh_client_*
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include
@@ -1179,7 +1181,7 @@ IGNORE_PREFIX          =
 # If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
 # The default value is: YES.
 
-GENERATE_HTML          = YES
+GENERATE_HTML          = NO
 
 # The HTML_OUTPUT tag is used to specify where the HTML docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/wolfHSM/Makefile
+++ b/wolfHSM/Makefile
@@ -77,4 +77,4 @@ pdf-prep: api
 	$(Q)perl -i -pe "s/(?<=md\#function\-)(.*)(?=\))/\$$1=~s#-#_#gr/ge" build/pdf/*.md
 	$(Q)perl -i -pe "s/(?<=md\#typedef\-)(.*)(?=\))/\$$1=~s#-#_#gr/ge" build/pdf/*.md
 	$(Q)perl -i -pe "s/(?<=md\#enum\-)(.*)(?=\))/\$$1=~s#-#_#gr/ge" build/pdf/*.md
-
+	$(Q)cat build/pdf/wh__client_8h.md build/pdf/wh__client__crypto_8h.md build/pdf/wh__server_8h.md >> build/pdf/appendix01.md

--- a/wolfHSM/mkdocs.yml
+++ b/wolfHSM/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
     - "8. Porting wolfHSM": chapter08.md
     - "9. API Reference":
       - Client API: wh__client_8h.md
+      - Client Crypto API: wh__client__crypto_8h.md
       - Server API: wh__server_8h.md
 theme:
   name: null


### PR DESCRIPTION
In wolfHSM documentation
- fixed formatting for Server API and Client API
- Added Client Crypto API
- fixed build for pdf version not including these API files.