### PR TITLE
[JA] wolfSSL JNI/JSSE: update pass on existing manual contents

### DIFF
--- a/wolfCrypt-JNI/src-ja/chapter01.md
+++ b/wolfCrypt-JNI/src-ja/chapter01.md
@@ -1,8 +1,8 @@
 # イントロダクション
 
 
-JCE (Java Cryptography Extension) フレームワークは、カスタムの暗号化サービス プロバイダーのインストールをサポートします。この仕組みにより、Java セキュリティ API によって使用される基本的な暗号化機能のサブセットを実装できます。
+JCE (Java Cryptography Extension) は、カスタムの暗号化サービス プロバイダーのインストールをサポートします。この仕組みにより、Java セキュリティ API によって使用される基本的な暗号化機能のサブセットを実装できます。
 
-このドキュメントでは、wolfCrypt JCE プロバイダーの詳細と使用方法について説明します。 wolfCrypt JCE プロバイダー (wolfJCE) は、ネイティブの wolfCrypt 暗号化ライブラリーをラップして、Java Security API との互換性を確保します。 [こちら](https://github.com/wolfSSL/wolfcrypt-jni)のGithubリポジトリを参照してください。
+このマニュアルでは、wolfCrypt JCE プロバイダーの詳細と使用方法について説明します。 wolfCrypt JCE プロバイダー (wolfJCE) は、ネイティブの wolfCrypt 暗号化ライブラリーをラップして、Java Security API との互換性を確保します。 wolfCrypt JNI/JCEについては、[こちら](https://github.com/wolfSSL/wolfcrypt-jni)のGithubリポジトリを参照してください。
 
-wolfcrypt-jni パッケージには、JCE プロバイダーに加えて、wolfCrypt JNI ラッパーの両方が含まれています。 JNI ラッパーは、必要に応じて単独で使用できます。
+wolfcrypt-jni パッケージには、JCE プロバイダーとwolfCrypt JNI ラッパーの両方が含まれています。 JNI ラッパーは、必要に応じて単独で使用できます。

--- a/wolfCrypt-JNI/src-ja/chapter02.md
+++ b/wolfCrypt-JNI/src-ja/chapter02.md
@@ -1,57 +1,49 @@
 #  システム要件
 
 ##  Java / JDK
-wolfJCE では、ホストシステムに Java をインストールする必要があります。 Oracle JDK や OpenJDK など、ユーザーや開発者が利用できる JDK バリアントがいくつかあります。 wolfJCE は現在、OpenJDK、Oracle JDK、および Android でテストされています。 OpenJDK と Android では、JCE プロバイダーがコード署名されている必要はありませんが、Oracle JDK では必要です。 コード署名の詳細については、[第 7 章](chapter07.md#jar-code-signing)を参照してください。
 
-参考までに、wolfJCE がテストされた OpenJDK の特定のバージョンは次のとおりです：
+wolfJCE では、ホストシステムに Java をインストールする必要があります。 Oracle JDK や OpenJDK など、ユーザーや開発者が利用できる JDK バリアントがいくつかあります。 wolfJCEは現在、OpenJDK、Oracle JDK、Amazon Coretto、Zulu、Temurin、Microsoft JDK、およびAndroidでテストされています。OpenJDK と Android では、JCE プロバイダーがコード署名されている必要はありませんが、Oracle JDK では必要です。 コード署名の詳細については、[第 7 章](chapter07.md#jar-code-signing)を参照してください。
 
-
-```
-$ java -version
-Openjdk version “1.8.0_91”
-OpenJDK Runtime Environment (build 1.8.0_91-8u91-b14-3ubuntu1~15.10.1~b14)
-OpenJDK 64-Bit Server VM (build 25.91-b14, mixed mode)
-```
-また、Oracle JDK 1.8.0_121 および Android 24 でもテストされています。
 
 ##  JUnit
-単体テストを実行するには、JUnit が開発システムにインストールされている必要があります。 JUnit は、プロジェクトの Web サイト (www.junit.org) からダウンロードできます
 
-Unix/Linux/OSX システムに JUnit をインストールするには:
-1. [junit.org/junit4/]() から "**junit-4.13.jar**" と "**hamcrest-all-1.3.jar**" をダウンロードします。 執筆時点では、前述の .jar ファイルは次のリンクからダウンロードできます:
+単体テストを実行するには、JUnit4 が開発システムにインストールされている必要があります。 JUnit4 は、プロジェクトの Web サイト (www.junit.org) からダウンロードできます
 
-リンク: [junit-4.13.jar](https://search.maven.org/search?q=g:junit%20AND%20a:junit)<br>
-リンク: [hamcrest-all-1.3.jar](https://search.maven.org/artifact/org.hamcrest/hamcrest-all/1.3/jar)
+Unix/Linux/OSX システムに JUnit4 をインストールするには:
+1) [junit.org/junit4/]() から "**junit-4.13.jar**" と "**hamcrest-all-1.3.jar**" をダウンロードします。 執筆時点では、前述の .jar ファイルは次のリンクからダウンロードできます:
 
-2. これらの JAR ファイルをシステムに配置し、その場所を指すように `JUNIT_HOME` を設定します：
+Junit: [junit-4.13.jar](https://search.maven.org/search?q=g:junit%20AND%20a:junit)
+
+Hamcrest: [hamcrest-all-1.3.jar](https://search.maven.org/artifact/org.hamcrest/hamcrest-all/1.3/jar)
+
+2) これらの JAR ファイルをシステムに配置し、その場所を指すように `JUNIT_HOME` を設定します：
 
 ```
-    $ export JUNIT_HOME=/path/to/jar/files
+$ export JUNIT_HOME=/path/to/jar/files
 ```
 
 ## make と ant
 
 "make" と "ant" は、それぞれネイティブ C コードと Java コードのコンパイルに使用されます。
-
 これらが開発マシンにインストールされていることを確認してください。
 
 
 ## wolfSSL / wolfCrypt ライブラリ
 
-ネイティブ wolfCrypt ライブラリのラッパーとして、wolfSSL をホスト プラットフォームにインストールし、インクルードおよびライブラリ検索パスに配置する必要があります。 wolfJCE は、wolfSSL/wolfCrypt ネイティブ ライブラリの FIPS または非 FIPS バージョンに対してコンパイルできます。
+ネイティブ wolfCrypt ライブラリのラッパーとして、[wolfSSL](https://wolfssl.jp/products/wolfssl/) をインストールし、インクルードおよびライブラリ検索パスに配置する必要があります。 wolfJCE は、wolfSSL/wolfCrypt ネイティブ ライブラリの FIPS 140-2/3 または非 FIPS バージョンに対してコンパイルできます。
 
 
 ###  wolfSSL / wolfCrypt のコンパイル 
 
-wolfJCE で使用するために Unix/Linux 環境で wolfSSL をコンパイルおよびインストールするには、wolfSSL マニュアルのビルド手順に従ってください。 wolfSSL をコンパイルする最も一般的な方法は、Autoconf システムを使用することです。
+Unix/Linux 環境で wolfSSL をコンパイルおよびインストールするには、[wolfSSL マニュアル](https://www.wolfssl.com/documentation/manuals/jp/wolfssl/)のビルド手順に従ってください。 wolfSSL をコンパイルする最も一般的な方法は、Autoconf システムを使用することです。
 
-wolfSSL (wolfssl-x.x.x)、wolfSSL FIPS リリース (wolfssl-x.x.x-commercial-fips)、または wolfSSL FIPS Ready リリースをインストールできます。いずれの場合も、 ./configure　スクリプト実行時に`--enable-keygen` オプションが必要です。
+wolfSSL (wolfssl-x.x.x)、wolfSSL FIPS リリース (wolfssl-x.x.x-commercial-fips)、または wolfSSL FIPS Ready リリースをビルドし、インストールできます。いずれの場合も、 ./configure　スクリプト実行時にパッケージ固有のconfigureオプション要件（例：`--enable-fips`）に加えて、`--enable-jni` を使用する必要があります。
 
 
 **wolfSSL 標準ビルド**:
 ```
 $ cd wolfssl-x.x.x
-$ ./configure --enable-keygen
+$ ./configure --enable-jni
 $ make check
 $ sudo make install
 ```
@@ -60,7 +52,7 @@ $ sudo make install
 
 ```
 $ cd wolfssl-x.x.x-commercial-fips
-$ ./configure --enable-fips --enable-keygen
+$ ./configure --enable-fips --enable-jni
 $ make check
 $ sudo make install
 ```
@@ -69,7 +61,16 @@ $ sudo make install
 
 ```
 $ cd wolfssl-x.x.x-commercial-fips
-$ ./configure --enable-fips=v2 --enable-keygen
+$ ./configure --enable-fips=v2 --enable-jni
+$ make check
+$ sudo make install
+```
+
+**wolfSSL FIPSv5 ビルド**:
+
+```
+$ cd wolfssl-x.x.x-commercial-fips
+$ ./configure --enable-fips=v5 --enable-jni
 $ make check
 $ sudo make install
 ```
@@ -78,7 +79,7 @@ $ sudo make install
 
 ```
 $ cd wolfssl-x.x.x-commercial-fips
-$ ./configure --enable-fips=ready --enable-keygen
+$ ./configure --enable-fips=ready --enable-jni
 $ make check
 $ sudo make install
 ```

--- a/wolfCrypt-JNI/src-ja/chapter03.md
+++ b/wolfCrypt-JNI/src-ja/chapter03.md
@@ -17,12 +17,15 @@ Mac OSXにインストールする場合:
 $ cd wolfcrypt-jni
 $ cp makefile.macosx makefile
 ```
-次に、 "make" を使用してネイティブ (C ソース) コードをコンパイルします:
+
+次に、 "make" を使用してネイティブ (C ソース) コードをコンパイルします。
+これにより、ネイティブJNI共有ライブラリ（`libwolfcryptjni.so/dylib`）が生成されます：
 
 ```
 $ cd wolfcrypt-jni
 $ make
 ```
+
 Java ソースのコンパイルには "ant" を使用します。 JNI または JCE (JNI を含む) パッケージをデバッグ モードまたはリリース モードでコンパイルするための ant ターゲットがいくつかあります。 ターゲットを指定せずに "ant" を実行すると、使用オプションが表示されます：
 
 
@@ -40,18 +43,20 @@ build:
 [echo] build-jce-release | builds release JAR with JNI and JCE classes
 [echo] ----------------------------------------------------------------------------
 ```
+
 必要に応じてビルドターゲットを指定してください。 たとえば、リリース モードで wolfJCE プロバイダーをビルドする場合は、次を実行します：
 
 ```
 $ ant build-jce-release
 ```
-また、JUnit テストを実行するには、次のコマンドを実行します。 これにより、実行されたビルド (JNI と JCE) に一致するテストのみがコンパイルされ、それらのテストも実行されます。
 
+JUnitテストを実行するには、`ant test` を実行してください。これにより、実行されたビルド（JNIとJCE）に一致するテストのみがコンパイル、実行されます。
 
 ```
 $ ant test
 ```
-Java JAR とネイティブ ライブラリの両方を消去するには:
+
+Java JAR とネイティブ ライブラリの両方を消去するには、次のようにします:
 
 ```
 $ ant clean
@@ -60,6 +65,6 @@ $ make clean
 
 ## APIマニュアル（Javadoc）
 
-`ant` を実行すると、`wolfcrypt-jni/docs` ディレクトリの下に一連の Javadoc が生成されます。 ルートドキュメントを表示するには、Web ブラウザで次のファイルを開きます：
+`ant` を実行すると、`wolfcrypt-jni/docs/javadoc` ディレクトリの下に一連の Javadoc が生成されます。 Javadocインデックスを表示するには、Web ブラウザで次のファイルを開きます：
 
-`wolfcrypt-jni/docs/index.html`
+`wolfcrypt-jni/docs/javadoc/index.html`

--- a/wolfCrypt-JNI/src-ja/chapter05.md
+++ b/wolfCrypt-JNI/src-ja/chapter05.md
@@ -4,37 +4,44 @@ wolfJCE は、"wolfcrypt-jni" JNI ラッパー ライブラリにバンドルさ
 
 JNI ラッパーのみを使用したいユーザーの場合、JCE プロバイダー クラスを含まないバージョンの "wolfcrypt-jni.jar" をコンパイルすることができます。
 
-wolfJCE / wolfCrypt JNI パッケージ構造:
+**wolfJCE / wolfCrypt JNI パッケージ構造:**
 
 
 ```
 wolfcrypt-jni /
-AUTHORS
-build.xml                          ant ビルドスクリプト
-COPYING
-docs /                             Javadoc
-jni /                              ネイティブC JNI バインディングソースファイル
-lib /                              コンパイル成果物（ライブラリ）の出力先
-LICENSING
-Makefile generic                   Makefile
-Makefile.linux                     Linux用　Makefile
-Makefile.osx                       OSX用 Makefile
-README_JCE.md
-README.md
-src /
-    main/java/                     Java ソースファイル
-    test/java/                     テストソースファイル
+   .github                        GitHub Actionsワークフロー
+   AUTHORS
+   COPYING
+   ChangeLog.md                   更新履歴
+   IDE/                           IDEプロジェクトファイル
+       WIN/                       Visual Studioプロジェクトファイル
+   LICENSING
+   README.md                      メインREADME
+   README_JCE.md                  wolfJCE README
+   build.xml                      antビルドスクリプト
+   docs /                         Javadocs
+   examples/                      サンプルアプリケーションと証明書/鍵
+       certs/                     サンプル証明書/鍵/KeyStores
+       provider/                  JCEサンプルアプリ
+   jni/                           ネイティブC JNIバインディングソースファイル
+   lib/                           コンパイル成果物（ライブラリ）の出力先
+   makefile.linux                 Linux用のMakefile
+   makefile.osx                   OSX用のMakefile
+   pom.xml                        Mavenビルドファイル
+   rpm/                           Linux rpmファイル
+   scripts/                       テストスクリプト（Facebook Infer等）
+   src/                           ソースコード
+       main/java                  Javaソースファイル
 ```
 
-wolfJCE プロバイダーのソース コードは "src/main/java/com/wolfssl/provider/jce" ディレクトリにあり、"**com.wolfssl.provider.jce**" Java パッケージの一部です。
- 
-wolfCrypt JNI ラッパーは "src/main/java/com/wolfssl/wolfcrypt" ディレクトリにあり、"**com.wolfssl.wolfcrypt**" Java パッケージの一部です。 このパッケージは wolfJCE クラスによって使用されるため、JCE のユーザーはこのパッケージを直接使用する必要はありません。
+wolfJCEプロバイダーのソースコードは `src/main/java/com/wolfssl/provider/jce` ディレクトリにあり、「**com.wolfssl.provider.jce**」Javaパッケージの一部です。
 
-wolfCrypt-JNI と wolfJCE がコンパイルされると、出力 JAR とネイティブ共有ライブラリが "./lib" ディレクトリに配置されます。 これらには、JCE ビルドがコンパイルされると、wolfCrypt JNI ラッパーと wolfJCE プロバイダーの両方が含まれることに注意してください。
+wolfCrypt JNIラッパーは `src/main/java/com/wolfssl/wolfcrypt` ディレクトリにあり、「**com.wolfssl.wolfcrypt**」Javaパッケージの一部です。このパッケージはwolfJCEクラスによって使用されるため、JCEのユーザーはこのパッケージを直接使用する必要はありません。
 
+wolfCrypt JNIとwolfJCEがコンパイルされると、出力JARとネイティブ共有ライブラリは `./lib` ディレクトリに配置されます。JCEビルドがコンパイルされる際、これらにはwolfCrypt JNIラッパーとwolfJCEプロバイダーの両方が含まれることにご注意ください。
 
 ```
 lib/
-    libwolfcryptjni.so
+    libwolfcryptjni.so (libwolfcryptjni.dylib)
     wolfcrypt-jni.jar
 ```

--- a/wolfCrypt-JNI/src-ja/chapter06.md
+++ b/wolfCrypt-JNI/src-ja/chapter06.md
@@ -1,4 +1,4 @@
-#  サポートしているアルゴリズムとクラス
+#  サポートしているJCEアルゴリズムとクラス
 
 wolfJCE は現在、次のアルゴリズムとクラスをサポートしています:
 
@@ -10,11 +10,15 @@ wolfJCE は現在、次のアルゴリズムとクラスをサポートしてい
         SHA-512
 
     SecureRandom Class
+        DEFAULT (maps to HashDRBG)
         HashDRBG
 
     Cipher Class
         AES/CBC/NoPadding
+        AES/CBC/PKCS5Padding
+        AES/GCM/NoPadding
         DESede/CBC/NoPadding
+        RSA
         RSA/ECB/PKCS1Padding
 
     Mac Class
@@ -41,6 +45,23 @@ wolfJCE は現在、次のアルゴリズムとクラスをサポートしてい
         ECDH
 
     KeyPairGenerator Class
+        RSA
         EC
         DH
 
+    CertPathValidator Class
+        PKIX
+
+    SecretKeyFactory
+        PBKDF2WithHmacSHA1
+        PBKDF2WithHmacSHA224
+        PBKDF2WithHmacSHA256
+        PBKDF2WithHmacSHA384
+        PBKDF2WithHmacSHA512
+        PBKDF2WithHmacSHA3-224
+        PBKDF2WithHmacSHA3-256
+        PBKDF2WithHmacSHA3-384
+        PBKDF2WithHmacSHA3-512
+
+    KeyStore
+        WKS

--- a/wolfCrypt-JNI/src-ja/chapter07.md
+++ b/wolfCrypt-JNI/src-ja/chapter07.md
@@ -1,9 +1,8 @@
 #  JAR コードの署名
 
-Oracle JDK/JVM では、Oracle が発行したコード署名証明書によって JCE プロバイダーが署名されている必要があります。 wolfcrypt-jni パッケージの ant ビルド スクリプトは、コンパイル前にパッケージ ディレクトリのルートにカスタム プロパティ ファイルを配置することにより、生成された"wolfcrypt-jni.jar" ファイルのコード署名をサポートします。
+Oracle JDK/JVM では、Oracleが発行したコード署名証明書によってJCEプロバイダーが署名されている必要があります。 wolfcrypt-jniパッケージのantビルドスクリプトは、コンパイル前にパッケージディレクトリのルートにカスタムプロパティファイルを配置することにより、生成された`wolfcrypt-jni.jar` ファイルのコード署名をサポートします。
 
-自動コード署名を有効にするには、"codeSigning.properties" というファイルを作成し、" wolfcrypt-jni" パッケージのルートに配置します。 これは、以下を含むプロパティ ファイルです:
-
+自動コード署名を有効にするには、`codeSigning.properties` というファイルを作成し、`wolfcrypt-jni` パッケージのルートに配置します。これは、以下を含むプロパティファイルです:
 
 ```
 sign.alias=<signing alias in keystore>
@@ -11,15 +10,16 @@ sign.keystore=<path to signing keystore>
 sign.storepass=<keystore password>
 sign.tsaurl=<timestamp server url>
 ```
-"ant" または "ant test" の実行時にこのファイルが存在する場合、提供されたキーストアとエイリアスを使用して "wolfcrypt-jni.jar" に署名します。
+`ant` または `ant test` の実行時にこのファイルが存在する場合、提供されたキーストアとエイリアスを使用して `wolfcrypt-jni.jar` に署名します。
 
 ## 事前署名JARファイルの利用
 
-wolfSSL社 は、Oracle JDK で wolfJCE を認証できるようにする、Oracle からの独自のコード署名証明書のセットを持っています。 wolfJCE のリリースごとに、wolfSSL は、次の場所にある "wolfcrypt-jni.jar" の署名済みバージョンをいくつかリリースしています：
+wolfSSL社は、Oracle JDKでwolfJCEを認証できるようにする、Oracleからの独自のコード署名証明書のセットを持っています。 wolfJCEのリリースごとに、wolfSSLは、次の場所にある`wolfcrypt-jni.jar`の署名済みバージョンをいくつかリリースしています：
 
-
-wolfcrypt-jni-X.X.X/lib/signed/debug/wolfcrypt-jni.jar<br>
-wolfcrypt-jni-X.X.X/lib/signed/release/wolfcrypt-jni.jar<br>
+```
+wolfcrypt-jni-X.X.X/lib/signed/debug/wolfcrypt-jni.jar
+wolfcrypt-jni-X.X.X/lib/signed/release/wolfcrypt-jni.jar
+```
 
 この事前に署名された JAR は、Java ソース ファイルを再コンパイルすることなく、JUnit テストで使用できます。 この JAR ファイルに対して JUnit テストを実行するには:
 

--- a/wolfCrypt-JNI/src-ja/chapter08.md
+++ b/wolfCrypt-JNI/src-ja/chapter08.md
@@ -1,7 +1,6 @@
 #  使用方法
 
-使用方法については、上記の [第 6 章](chapter06#supported-algorithms-and-classes) で指定されているクラスの Oracle/OpenJDK Javadoc に従ってください。 java.security ファイルで同じアルゴリズムを提供する他のプロバイダーよりも優先順位が低く設定されている場合は、 "wolfJCE" プロバイダーを明示的に要求する必要があることに注意してください。 たとえば、SHA-1 の MessageDigest クラスで wolfJCE プロバイダーを使用するには、次のように MessageDigest オブジェクトを作成します
-
+使用方法については、上記の [第6章](chapter06#supported-algorithms-and-classes) で指定されているクラスの Oracle/OpenJDK Javadoc に従ってください。 `java.security` ファイルで同じアルゴリズムを提供する他のプロバイダーよりも優先順位が低く設定されている場合は、 `wolfJCE`プロバイダーを明示的に要求する必要があることに注意してください。 たとえば、SHA-1のMessageDigestクラスでwolfJCEプロバイダーを使用するには、次のようにMessageDigestオブジェクトを作成します：
 
 ```
 MessageDigest md = MessageDigest.getInstance(“SHA-1”, “wolfJCE”);

--- a/wolfSSL-JNI/src-ja/chapter01.md
+++ b/wolfSSL-JNI/src-ja/chapter01.md
@@ -1,10 +1,9 @@
 # イントロダクション
 
-wolfSSL JNI/JSSE は、Java Secure Socket Extension のプロバイダー実装です。 また、ネイティブの wolfSSL SSL/TLS ライブラリの薄い JNI ラッパーも含んでいます。
+wolfSSL JNI/JSSE は、Java Secure Socket Extension (JSSE)のプロバイダー実装です。 また、ネイティブの wolfSSL SSL/TLS ライブラリの薄い JNI ラッパーも含んでいます。代わりにJCE（Java Cryptography Extension）プロバイダーをお探しの場合は、[wolfCrypt JNI/JCE](https://www.wolfssl.com/documentation/manuals/jp/wolfcryptjni/)を参照してください。wolfSSLはこれらのプロバイダー（JSSEとJCE）の両方を積極的にメンテナンスしています。
 
 Java Secure Socket Extension ( **JSSE** ) フレームワークは、セキュリティプロバイダのインストールをサポートしています。 セキュリティプロバイダーは、SSL/TLS など、Java JSSE セキュリティ API で使用される機能のサブセットを実装できます。
 
-このドキュメントでは、wolfSSL の JSSE プロバイダーの実装 "**wolfJSSE**" について説明しています。 wolfJSSE は、ネイティブの wolfSSL SSL/TLS ライブラリをラップします。 このインターフェースにより、Java アプリケーションは [TLS 1.3](https://www.wolfssl.com/tls13)までの現在の SSL/TLS 標準、[FIPS 140-2 および 140-3](https://www.wolfssl.com/license/fips/) サポート、パフォーマンスの最適化、ハードウェア暗号化のサポート、[商用サポート](https://www.wolfssl.com/products/support-and-maintenance/)等々のwolfSSL を使用して得られるすべての利点を享受できます。
+このドキュメントでは、wolfSSL の JSSE プロバイダーの実装 "**wolfJSSE / wolfProvider**" について説明しています。 wolfJSSE は、ネイティブの wolfSSL SSL/TLS ライブラリをラップします。 このインターフェースにより、Java アプリケーションは [TLS 1.3](https://wolfssl.jp/products/product-wolfssl-tls1-3/)までの現在の SSL/TLS 標準、[FIPS 140-2 および 140-3](https://wolfssl.jp/products/wolfcrypt-fips/) サポート、パフォーマンスの最適化、ハードウェア暗号化のサポート、[商用サポート](https://wolfssl.jp/license/support-packages/)等々のwolfSSL を使用して得られるすべての利点を享受できます。
 
-wolfJSSE は、"**wolfssljni**"パッケージの一部として配布されます。 このパッケージには、wolfSSL 用の薄い JNI ラッパーと wolfJSSE プロバイダーの両方が含まれています。
-
+wolfJSSE は、"**wolfssljni**"パッケージの一部として配布されます。

--- a/wolfSSL-JNI/src-ja/chapter02.md
+++ b/wolfSSL-JNI/src-ja/chapter02.md
@@ -9,19 +9,17 @@ wolfJSSE では、ホスト システムに Java をインストールする必�
     + OpenJDK
     + Zulu JDK
     + Amazon Coretto
-- Android
-
-wolfSSL JNI/JSSE のビルド システムは、現時点でMicrosoft Windows で実行するようにセットアップされていません。この件について興味がある方は[facts@wolfssl.com](mailto:facts@wolfssl.com)までお問い合わせください。
-
-"IDE/Android"の下に含まれるAndroid Studioのサンプルプログラムプロジェクトは、Linux と Windows の両方でテストされています。
-
+- Mac OSX
+- Windows (Visual Studio)
+- Android Studio
+- Android AOSP
 
 ##  JUnit
 
-ユニットテストを実行するには、開発システムに JUnit 4 がインストールされている必要があります。JUnit は、プロジェクトの Web サイト[www.junit.org](http://www.junit.org)
+ユニットテストを実行するには、開発システムに JUnit4 がインストールされている必要があります。JUnit4 は、プロジェクトの Web サイト[www.junit.org](http://www.junit.org)
 からダウンロードできます。
 
-Unix/Linux/OSX システムに JUnit をインストールするには:
+Unix/Linux/OSX システムに JUnit4 をインストールするには:
 
 1) [junit.org/junit4/]() から "**junit-4.13.2.jar**" と " **hamcrest-all-1.3.jar**" をダウンロードします。 執筆時点では、上記の .jar ファイルは次のリンクからダウンロードできます。
 
@@ -39,11 +37,7 @@ $ export JUNIT_HOME=/path/to/jar/files
 
 ##  システム要件 (gcc、ant)
 
-**gcc** と **ant** がそれぞれCコードとJavaコードのコンパイルに使用されます。開発システム上に上記がインストールされていることを確認してください。 
-
-
-**注意事項**: `java.sh` スクリプトは、Java のインストールフォルダとして一般的なロケーションを使用します。 Java のインストールフォルダが異なる場合、`java.sh` の実行時にエラーが発生する可能性があります。 この場合、`java.sh` を環境に合わせて変更する必要があります。
-
+**gcc** と **ant** は、それぞれネイティブCコードとJavaコードのコンパイルに使用されます。これらが開発マシンにインストールされていることを確認してください。**ant** の代わりに **maven** でコンパイルすることもできます。
 
 
 ##  wolfSSL SSL/TLS ライブラリ

--- a/wolfSSL-JNI/src-ja/chapter06.md
+++ b/wolfSSL-JNI/src-ja/chapter06.md
@@ -1,18 +1,22 @@
 #  サポートしているアルゴリズムとクラス
 
 
-wolfJSSE は現在、次の JSSE クラスの実装を提供しています：
+wolfJSSE は、次の JSSE クラスを拡張または実装しています：
 
-- SSLContext
-    + TLS 1.0, TLS 1.1, TLS 1.2, TLS 1.3
-- SSLEngine
-- SSLSession
-- SSLSocket
-- SSLServerSocket
-- SSLSocketFactory
-- SSLServerSocketFactory
-- KeyManagerFactory
-- X509KeyManager
-- TrustManagerFactory
-- X509TrustManager
-- X509Certificate
+   javax.net.ssl.SSLContextSpi
+       SSL, TLS, DEFAULT, TLSv1, TLSv1.1, TLSv1.2, TLSv1.3
+   javax.net.ssl.KeyManagerFactorySpi
+       PKIX, X509, SunX509
+   javax.net.ssl.TrustManagerFactorySpi
+       PKIX, X509, SunX509
+   javax.net.ssl.SSLEngine
+   javax.net.ssl.SSLSession / ExtendedSSLSession
+   javax.net.ssl.X509KeyManager / X509ExtendedKeyManager
+   javax.net.ssl.X509TrustManager / X509ExtendedTrustManager
+   javax.net.ssl.SSLServerSocket
+   javax.net.ssl.SSLServerSocketFactory
+   javax.net.ssl.SSLSocket
+   javax.net.ssl.SSLSocketFactory
+   javax.net.ssl.SSLSessionContext
+   java.security.cert.X509Certificate
+   javax.security.cert.X509Certificate


### PR DESCRIPTION
following https://github.com/wolfSSL/documentation/pull/142 .
Some URLs have been changed to the Japanese version.