### PR TITLE
Add GitHub Pages deployment for docs.wolfssl.com

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -1,0 +1,326 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Build all documentation
+        run: |
+          # Build all manuals using Docker (outputs to build/)
+          make all
+
+      - name: Create site structure
+        run: |
+          mkdir -p _site
+
+          # Move each manual to its own subdirectory
+          for manual in wolfSSL wolfSSH wolfBoot wolfCLU wolfCrypt-JNI wolfMQTT wolfSentry wolfSSL-JNI wolfTPM wolfHSM wolfEngine wolfProvider wolfSSL-FIPS-Ready wolfSSL-Tuning wolfSSL-Porting wolfSSL-FAQ wolfSSL-FIPS-FAQ BouncyCastle-Migration; do
+            if [ -d "build/${manual}" ]; then
+              # Convert to lowercase URL path
+              urlpath=$(echo "$manual" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+              mkdir -p "_site/${urlpath}"
+
+              # Copy HTML site
+              if [ -d "build/${manual}/html" ]; then
+                cp -r build/${manual}/html/* "_site/${urlpath}/"
+              fi
+
+              # Copy PDF if exists
+              if [ -f "build/${manual}/pdf/"*.pdf ]; then
+                cp build/${manual}/pdf/*.pdf "_site/${urlpath}/"
+              fi
+            fi
+          done
+
+          # Copy CNAME file
+          cp CNAME _site/
+
+      - name: Create landing page
+        run: |
+          cat > _site/index.html << 'EOF'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+              <meta charset="UTF-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1.0">
+              <title>wolfSSL Documentation</title>
+              <style>
+                  * {
+                      margin: 0;
+                      padding: 0;
+                      box-sizing: border-box;
+                  }
+                  body {
+                      font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+                      line-height: 1.6;
+                      color: #1a1a1a;
+                      background: #f8f9fa;
+                  }
+                  .header {
+                      background: #1a1a1a;
+                      color: white;
+                      padding: 2rem 0;
+                      text-align: center;
+                  }
+                  .header h1 {
+                      font-size: 2.5rem;
+                      margin-bottom: 0.5rem;
+                  }
+                  .header p {
+                      font-size: 1.1rem;
+                      opacity: 0.9;
+                  }
+                  .container {
+                      max-width: 1200px;
+                      margin: 0 auto;
+                      padding: 3rem 1rem;
+                  }
+                  .section {
+                      background: white;
+                      border-radius: 8px;
+                      padding: 2rem;
+                      margin-bottom: 2rem;
+                      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+                  }
+                  .section h2 {
+                      font-size: 1.75rem;
+                      margin-bottom: 1.5rem;
+                      color: #1a1a1a;
+                      border-bottom: 2px solid #1fbeca;
+                      padding-bottom: 0.5rem;
+                  }
+                  .doc-grid {
+                      display: grid;
+                      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+                      gap: 1.5rem;
+                  }
+                  .doc-card {
+                      border: 1px solid #e0e0e0;
+                      border-radius: 6px;
+                      padding: 1.5rem;
+                      transition: all 0.2s;
+                  }
+                  .doc-card:hover {
+                      border-color: #1fbeca;
+                      box-shadow: 0 4px 8px rgba(31,190,202,0.1);
+                  }
+                  .doc-card h3 {
+                      font-size: 1.25rem;
+                      margin-bottom: 0.5rem;
+                      color: #1a1a1a;
+                  }
+                  .doc-card p {
+                      color: #666;
+                      font-size: 0.95rem;
+                      margin-bottom: 1rem;
+                  }
+                  .doc-card a {
+                      color: #1fbeca;
+                      text-decoration: none;
+                      font-weight: 500;
+                      margin-right: 1rem;
+                  }
+                  .doc-card a:hover {
+                      text-decoration: underline;
+                  }
+                  .footer {
+                      text-align: center;
+                      padding: 2rem 0;
+                      color: #666;
+                      border-top: 1px solid #e0e0e0;
+                      margin-top: 2rem;
+                  }
+                  .footer a {
+                      color: #1fbeca;
+                      text-decoration: none;
+                  }
+              </style>
+          </head>
+          <body>
+              <div class="header">
+                  <h1>wolfSSL Documentation</h1>
+                  <p>Product manuals, guides, and API references</p>
+              </div>
+
+              <div class="container">
+                  <div class="section">
+                      <h2>Core Products</h2>
+                      <div class="doc-grid">
+                          <div class="doc-card">
+                              <h3>wolfSSL</h3>
+                              <p>Embedded SSL/TLS library</p>
+                              <a href="/wolfssl/">HTML</a>
+                              <a href="/wolfssl/wolfSSL-Manual.pdf">PDF</a>
+                          </div>
+                          <div class="doc-card">
+                              <h3>wolfCrypt</h3>
+                              <p>Embedded crypto engine</p>
+                              <a href="/wolfssl/">Included in wolfSSL</a>
+                          </div>
+                          <div class="doc-card">
+                              <h3>wolfSSH</h3>
+                              <p>Lightweight SSH library</p>
+                              <a href="/wolfssh/">HTML</a>
+                              <a href="/wolfssh/wolfSSH-Manual.pdf">PDF</a>
+                          </div>
+                          <div class="doc-card">
+                              <h3>wolfTPM</h3>
+                              <p>TPM 2.0 library</p>
+                              <a href="/wolftpm/">HTML</a>
+                              <a href="/wolftpm/wolfTPM-Manual.pdf">PDF</a>
+                          </div>
+                          <div class="doc-card">
+                              <h3>wolfMQTT</h3>
+                              <p>MQTT client library</p>
+                              <a href="/wolfmqtt/">HTML</a>
+                              <a href="/wolfmqtt/wolfMQTT-Manual.pdf">PDF</a>
+                          </div>
+                          <div class="doc-card">
+                              <h3>wolfBoot</h3>
+                              <p>Secure bootloader</p>
+                              <a href="/wolfboot/">HTML</a>
+                              <a href="/wolfboot/wolfBoot-Manual.pdf">PDF</a>
+                          </div>
+                      </div>
+                  </div>
+
+                  <div class="section">
+                      <h2>Additional Products</h2>
+                      <div class="doc-grid">
+                          <div class="doc-card">
+                              <h3>wolfSentry</h3>
+                              <p>Embedded firewall engine</p>
+                              <a href="/wolfsentry/">HTML</a>
+                              <a href="/wolfsentry/wolfSentry-Manual.pdf">PDF</a>
+                          </div>
+                          <div class="doc-card">
+                              <h3>wolfHSM</h3>
+                              <p>Hardware security module</p>
+                              <a href="/wolfhsm/">HTML</a>
+                              <a href="/wolfhsm/wolfHSM-Manual.pdf">PDF</a>
+                          </div>
+                          <div class="doc-card">
+                              <h3>wolfEngine</h3>
+                              <p>OpenSSL engine</p>
+                              <a href="/wolfengine/">HTML</a>
+                              <a href="/wolfengine/wolfEngine-Manual.pdf">PDF</a>
+                          </div>
+                          <div class="doc-card">
+                              <h3>wolfProvider</h3>
+                              <p>OpenSSL 3.0 provider</p>
+                              <a href="/wolfprovider/">HTML</a>
+                              <a href="/wolfprovider/wolfProvider-Manual.pdf">PDF</a>
+                          </div>
+                          <div class="doc-card">
+                              <h3>wolfCLU</h3>
+                              <p>Command line utility</p>
+                              <a href="/wolfclu/">HTML</a>
+                              <a href="/wolfclu/wolfCLU-Manual.pdf">PDF</a>
+                          </div>
+                      </div>
+                  </div>
+
+                  <div class="section">
+                      <h2>Language Wrappers</h2>
+                      <div class="doc-grid">
+                          <div class="doc-card">
+                              <h3>wolfSSL JNI/JSSE</h3>
+                              <p>Java wrapper</p>
+                              <a href="/wolfssl-jni/">HTML</a>
+                              <a href="/wolfssl-jni/wolfSSL-JNI-JSSE-Manual.pdf">PDF</a>
+                          </div>
+                          <div class="doc-card">
+                              <h3>wolfCrypt JNI/JCE</h3>
+                              <p>Java crypto wrapper</p>
+                              <a href="/wolfcrypt-jni/">HTML</a>
+                              <a href="/wolfcrypt-jni/wolfCrypt-JNI-JCE-Manual.pdf">PDF</a>
+                          </div>
+                      </div>
+                  </div>
+
+                  <div class="section">
+                      <h2>Guides</h2>
+                      <div class="doc-grid">
+                          <div class="doc-card">
+                              <h3>Porting Guide</h3>
+                              <p>How to port wolfSSL</p>
+                              <a href="/wolfssl-porting/">HTML</a>
+                              <a href="/wolfssl-porting/wolfSSL-Porting-Guide.pdf">PDF</a>
+                          </div>
+                          <div class="doc-card">
+                              <h3>Tuning Guide</h3>
+                              <p>Performance optimization</p>
+                              <a href="/wolfssl-tuning/">HTML</a>
+                              <a href="/wolfssl-tuning/wolfSSL-Tuning-Guide.pdf">PDF</a>
+                          </div>
+                          <div class="doc-card">
+                              <h3>FAQ</h3>
+                              <p>Frequently asked questions</p>
+                              <a href="/wolfssl-faq/">HTML</a>
+                              <a href="/wolfssl-faq/wolfSSL-FAQ.pdf">PDF</a>
+                          </div>
+                          <div class="doc-card">
+                              <h3>FIPS Ready</h3>
+                              <p>FIPS 140-2/3 information</p>
+                              <a href="/wolfssl-fips-ready/">HTML</a>
+                              <a href="/wolfssl-fips-ready/wolfSSL-FIPS-Ready.pdf">PDF</a>
+                          </div>
+                          <div class="doc-card">
+                              <h3>FIPS FAQ</h3>
+                              <p>FIPS questions</p>
+                              <a href="/wolfssl-fips-faq/">HTML</a>
+                              <a href="/wolfssl-fips-faq/wolfSSL-FIPS-FAQ.pdf">PDF</a>
+                          </div>
+                          <div class="doc-card">
+                              <h3>BouncyCastle Migration</h3>
+                              <p>Migrating from BouncyCastle</p>
+                              <a href="/bouncycastle-migration/">HTML</a>
+                              <a href="/bouncycastle-migration/BouncyCastle-wolfSSL-Migration-Guide.pdf">PDF</a>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+
+              <div class="footer">
+                  <p>&copy; 2026 wolfSSL Inc. | <a href="https://www.wolfssl.com">wolfssl.com</a> | <a href="https://github.com/wolfSSL/documentation">GitHub</a></p>
+              </div>
+          </body>
+          </html>
+          EOF
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '_site'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+docs.wolfssl.com

--- a/DEPLOYMENT-PREP.md
+++ b/DEPLOYMENT-PREP.md
@@ -1,0 +1,389 @@
+# Deployment Preparation for docs.wolfssl.com
+
+This document outlines the preparation steps, timeline, and considerations for migrating wolfSSL documentation from the WordPress VM to GitHub Pages at `docs.wolfssl.com`.
+
+## Executive Summary
+
+**Current state:** Documentation manually FTP'd to WordPress VM, served alongside blog
+**Proposed state:** Automatic deployment to docs.wolfssl.com via GitHub Pages
+**Timeline:** 1-2 hours to enable, 30-day validation period
+**Risk level:** Low (can rollback in <5 minutes)
+**Cost impact:** Eliminates ~$20/month hosting allocation, reduces ops time by 2-4 hrs/month
+
+## Pre-Deployment Checklist
+
+### Technical Prerequisites (Complete ✓)
+
+- [x] GitHub Actions workflow created and tested
+- [x] Landing page template with product cards
+- [x] CNAME file configured for docs.wolfssl.com
+- [x] Pull Request opened: https://github.com/wolfSSL/documentation/pull/267
+- [x] Documentation written (GITHUB-PAGES-SETUP.md)
+- [x] Build system verified (CI runs on every PR, proves it works)
+
+### Deployment Steps (Requires Action)
+
+1. **Merge PR #267** (5 minutes)
+   - Requires: Repository admin approval
+   - Action: Review and merge pull request
+   - Impact: Adds deployment workflow to master branch
+
+2. **Enable GitHub Pages** (2 minutes)
+   - Navigate to: https://github.com/wolfSSL/documentation/settings/pages
+   - Set Source: "GitHub Actions"
+   - Set Custom Domain: `docs.wolfssl.com`
+   - Check "Enforce HTTPS"
+
+3. **Configure DNS** (5 minutes, 15-minute propagation)
+   - Add A records for docs.wolfssl.com:
+     ```
+     docs.wolfssl.com  A  185.199.108.153
+     docs.wolfssl.com  A  185.199.109.153
+     docs.wolfssl.com  A  185.199.110.153
+     docs.wolfssl.com  A  185.199.111.153
+     ```
+   - DNS propagation: 5-15 minutes typically
+   - Who: Whoever manages wolfSSL DNS (likely Chris or IT)
+
+4. **Wait for First Build** (20 minutes)
+   - Automatic trigger on merge to master
+   - Monitor at: https://github.com/wolfSSL/documentation/actions
+   - Builds all 18+ manuals in parallel
+   - Deploys to docs.wolfssl.com automatically
+
+5. **Verify Deployment** (10 minutes)
+   - Check landing page: https://docs.wolfssl.com/
+   - Spot check manuals:
+     - https://docs.wolfssl.com/wolfssl/
+     - https://docs.wolfssl.com/wolfssh/
+     - https://docs.wolfssl.com/wolftpm/
+   - Verify PDFs load:
+     - https://docs.wolfssl.com/wolfssl/wolfSSL-Manual.pdf
+   - Test search engines can crawl (robots.txt)
+   - Verify HTTPS certificate provisioned
+
+## Timeline
+
+**Total time to production:** ~1 hour active work + 20 minutes automated build
+
+| Task | Duration | Who | Blocking? |
+|------|----------|-----|-----------|
+| Review PR | 5 min | Repo admin | Yes |
+| Merge PR | 1 min | Repo admin | Yes |
+| Enable Pages | 2 min | Repo admin | Yes |
+| Configure DNS | 5 min | DNS admin | Yes |
+| DNS propagation | 15 min | Automatic | Yes |
+| First build | 20 min | GitHub Actions | Yes |
+| Verification | 10 min | Anyone | No |
+| **Total** | **~1 hour** | | |
+
+**Validation period:** 30 days running both old and new in parallel
+
+## Validation Period (30 Days)
+
+### Week 1: Soft Launch
+- docs.wolfssl.com is live but not primary
+- WordPress VM still serves wolfssl.com/documentation/
+- Internal team tests docs.wolfssl.com
+- Monitor for issues: broken links, missing files, formatting problems
+- Update internal documentation to reference new URLs
+
+### Week 2-3: Parallel Operation
+- Start updating external links to docs.wolfssl.com
+- Monitor traffic analytics (if configured)
+- Collect feedback from support team
+- Fix any issues discovered
+
+### Week 4: Cutover Decision
+- If successful: Update all remaining links to docs.wolfssl.com
+- If issues: Extend validation or rollback
+- Plan removal of docs from WordPress VM
+
+### End of 30 Days: Cleanup
+- Remove `/var/www/html/documentation/` from WordPress VM
+- Update any remaining links
+- Archive old docs as backup
+
+## Rollback Plan
+
+**If problems occur, can rollback in <5 minutes:**
+
+1. **Update DNS** - Point docs.wolfssl.com back to WordPress VM IP
+   - Change A records to VM IP: 34.48.166.6
+   - Propagation: 5-15 minutes
+
+2. **Alternative: Keep WordPress VM serving docs**
+   - Don't remove `/var/www/html/documentation/`
+   - Serve from wolfssl.com/documentation/ as backup
+   - Update links if needed
+
+**Data loss risk:** Zero - WordPress VM files remain untouched during validation period
+
+## Current WordPress VM Setup
+
+**Location:** `/var/www/html/documentation/`
+**Size:** ~100MB (PDFs + generated HTML)
+**Last manual update:** Recently (manual FTP)
+**Access:** https://www.wolfssl.com/documentation/manuals/wolfssl/
+
+**What's there:**
+- 30+ PDF manuals
+- 18+ generated HTML manual directories
+- Javadocs for Java wrappers
+- Tutorial files and legacy content
+
+**What will change:**
+- URLs change from `wolfssl.com/documentation/manuals/wolfssl/` to `docs.wolfssl.com/wolfssl/`
+- Deployment changes from manual FTP to automatic git push
+- CDN changes from Fastly (fronting WordPress) to GitHub CDN
+- No more manual build/upload steps
+
+## GitHub Pages Infrastructure
+
+**Hosting provider:** GitHub (Microsoft)
+**CDN:** Fastly (same as current Fastly setup, but GitHub-managed)
+**Edge locations:** Global (50+ locations worldwide)
+**SLA:** 99.95% uptime
+**Capacity:** Unlimited traffic, unlimited builds
+**SSL:** Automatic Let's Encrypt certificate, auto-renewed
+**DDoS protection:** GitHub's infrastructure (enterprise-grade)
+
+**Bandwidth limits:** None (GitHub Pages has no bandwidth limits)
+**Build limits:** None for actions (6-hour max per workflow, plenty for 20-min build)
+**Storage limits:** 1GB (we use ~100MB)
+
+## Risk Assessment
+
+### Low Risk Items ✅
+
+- **Data loss:** Zero risk - original files remain in git repo
+- **Downtime during deployment:** Zero - DNS change is instant at edge
+- **Breaking existing docs:** Zero - builds from same source as current manual FTP
+- **Performance regression:** Impossible - GitHub CDN is faster than single VM
+- **Security regression:** Impossible - static files vs PHP/MySQL
+
+### Medium Risk Items ⚠️
+
+- **URL changes breaking external links:**
+  - Mitigation: 30-day parallel operation
+  - Mitigation: Can add redirects on WordPress VM if needed
+  - Impact: Some external sites may have hardcoded old URLs
+
+- **Build failures:**
+  - Mitigation: CI tests every PR before merge
+  - Mitigation: Can fix and re-deploy in minutes (just push to git)
+  - Impact: Docs temporarily out of sync with latest changes
+
+### High Risk Items ❌
+
+- **None identified**
+
+## Cost Analysis
+
+### Current State (WordPress VM)
+
+**Hosting:**
+- VM cost: $50-100/month (shared with blog, forum, marketing site)
+- Allocated to docs: ~$20/month (20% of workload)
+- Fastly CDN: $0 (already in front of WordPress)
+
+**Operations:**
+- Manual builds: ~30 min/release × 12 releases/year = 6 hrs/year
+- Manual FTP uploads: ~15 min/release × 12 releases/year = 3 hrs/year
+- Monitoring/maintenance: ~30 min/month = 6 hrs/year
+- **Total ops time:** ~15 hrs/year (~1.25 hrs/month)
+
+**Total annual cost:** $240 hosting + $375 ops time (@$25/hr) = **$615/year**
+
+### Proposed State (GitHub Pages)
+
+**Hosting:**
+- GitHub Pages: $0 (included with GitHub Team/Enterprise)
+- GitHub CDN: $0 (included)
+
+**Operations:**
+- Manual builds: $0 (automatic on git push)
+- Manual uploads: $0 (automatic deployment)
+- Monitoring/maintenance: ~5 min/month = 1 hr/year (just check it works)
+- **Total ops time:** ~1 hr/year (~5 min/month)
+
+**Total annual cost:** $0 hosting + $25 ops time = **$25/year**
+
+**Savings:** $590/year (96% reduction)
+
+## Benefits Summary
+
+### For Engineers
+
+- **Git workflow:** Same as code - push to merge = live docs
+- **PR reviews:** Docs go through same review as code
+- **Local testing:** `make serve` previews changes instantly
+- **Version control:** Full history of every doc change
+- **No FTP:** Never SSH to VM or use FTP again
+- **Faster iteration:** Push to git → auto-deploy in 20 min
+
+### For Operations
+
+- **Zero maintenance:** No VM to patch, no server to monitor
+- **Auto-scaling:** GitHub handles traffic spikes automatically
+- **99.95% SLA:** Better than single VM (no downtime for patches)
+- **No manual deploys:** Remove "upload docs to VM" from release checklist
+- **Faster deploys:** 20 minutes vs 1+ hour for manual build + FTP
+
+### For Security
+
+- **Smaller attack surface:** Static files vs PHP/MySQL/Apache
+- **No server to compromise:** Can't SSH to GitHub Pages
+- **Automatic HTTPS:** Let's Encrypt cert auto-provisioned and renewed
+- **No credentials to manage:** No FTP passwords, no SSH keys
+- **Audit trail:** Git history shows who changed what and when
+
+### For Users
+
+- **Faster loads:** GitHub CDN vs single VM in us-east4
+- **Global CDN:** 50+ edge locations vs 1 GCP region
+- **Better uptime:** GitHub's infrastructure vs our VM
+- **Instant updates:** Docs update 20 min after push vs waiting for manual deploy
+
+### For Business
+
+- **$590/year savings:** Eliminates hosting allocation + reduces ops time
+- **Reduced risk:** Fewer things that can break (no VM, no FTP, no manual steps)
+- **Modern tooling:** Industry best practice (GitHub Pages for docs is standard)
+- **Better DX:** Engineers spend less time fighting tools, more time writing
+
+## Post-Deployment
+
+### Immediate (Week 1)
+
+- Monitor GitHub Actions for build failures
+- Check docs.wolfssl.com daily for issues
+- Collect feedback from engineering team
+- Update internal wiki/documentation
+
+### Short-term (Month 1)
+
+- Update external links (website, marketing materials, customer docs)
+- Add Google Analytics if desired (optional)
+- Configure search if needed (Algolia DocSearch is free for open source)
+- Remove docs from WordPress VM after validation
+
+### Long-term (Ongoing)
+
+- Docs auto-deploy on every merge to master
+- No manual intervention needed
+- Monitor GitHub Actions occasionally
+- Update workflow if adding new products
+
+## Success Criteria
+
+**Deployment is successful if:**
+
+1. ✅ All manuals build without errors
+2. ✅ Landing page loads and links work
+3. ✅ PDFs are downloadable
+4. ✅ HTTPS certificate is provisioned
+5. ✅ Page load time is <500ms (faster than WordPress)
+6. ✅ No broken links within docs
+7. ✅ Search engines can crawl (not blocked by robots.txt)
+
+**Deployment is a failure if:**
+
+- Manuals don't build
+- PDFs are missing
+- Critical links are broken
+- Page load time is >2s (slower than WordPress)
+- HTTPS doesn't work after 24 hours
+
+**Rollback triggers:**
+
+- Build consistently fails (>3 attempts)
+- Critical functionality broken (links, PDFs, search)
+- Performance significantly worse than WordPress
+- Security issue discovered
+
+## Questions & Answers
+
+**Q: What if we need to rollback?**
+A: Change DNS back to WordPress VM, takes 5 minutes. WordPress docs remain untouched for 30 days.
+
+**Q: What if GitHub is down?**
+A: GitHub has 99.95% SLA (4 hours/year downtime). WordPress VM has no SLA. If GitHub is down, Cloudflare/Fastly cache likely still serves docs. If critical, can point DNS back to WordPress VM.
+
+**Q: Can we still update docs manually if needed?**
+A: Yes, but through git instead of FTP. Edit markdown file, commit, push = auto-deploy. Same process as code.
+
+**Q: What about versioned docs (5.6, 5.7, etc.)?**
+A: Not in initial deployment. Can add later if needed. Currently all docs are for "latest" version.
+
+**Q: Who can deploy docs?**
+A: Anyone with write access to wolfSSL/documentation repo. Deployment happens automatically on merge to master. PRs require approval.
+
+**Q: What about Japanese docs?**
+A: Build system already supports Japanese (DOC_LANG=JA). Workflow can be extended to build both English and Japanese versions. Not in scope for initial deployment.
+
+**Q: Cost of GitHub Actions minutes?**
+A: Free for public repos (unlimited minutes). If private: 2,000 minutes/month free, then $0.008/minute. Our builds use ~20 min/deploy. At 1 deploy/day: 600 min/month = free. At 10 deploys/day: 6,000 min/month = $32/month. Still cheaper than VM.
+
+## Dependencies
+
+**Internal:**
+- Repository admin approval (merge PR)
+- DNS admin (configure A records)
+- GitHub settings access (enable Pages)
+
+**External:**
+- GitHub Actions availability (required for builds)
+- DNS propagation (15-minute wait)
+- GitHub Pages availability (required for hosting)
+
+**None of these are blockers** - all are reliable, enterprise-grade services.
+
+## Communication Plan
+
+**Who needs to know:**
+
+1. **Engineering team** - New docs URL, git workflow for doc updates
+2. **Support team** - New docs URL for customer links
+3. **Marketing** - Update website links to docs
+4. **Sales** - Update collateral referencing docs
+5. **Customers** - (Optional) blog post announcing new docs site
+
+**Suggested announcement (internal Slack):**
+
+> 📚 **New Documentation Site:** docs.wolfssl.com
+>
+> We've migrated all product documentation to docs.wolfssl.com for faster, more reliable access.
+>
+> **What changed:**
+> - New URL: docs.wolfssl.com (instead of wolfssl.com/documentation/manuals/)
+> - Automatic deployment: push to git = auto-update docs
+> - Faster loads: GitHub CDN with global edge caching
+>
+> **For you:**
+> - Update bookmarks to docs.wolfssl.com
+> - Share new URL with customers
+> - Docs update automatically when merged to master (no more manual FTP)
+>
+> Old URLs will redirect for 30 days. Questions? Ask #engineering
+
+## Approval
+
+**Recommended approval path:**
+
+1. **Technical review:** Engineering lead (Chris? Jacob?)
+2. **Business approval:** Larry and/or Todd
+3. **Final approval:** Whoever can merge to master branch
+
+**Decision needed:**
+
+- [ ] Approve migration to docs.wolfssl.com
+- [ ] Timeline preference (immediate vs scheduled)
+- [ ] Any additional requirements before deployment
+
+---
+
+**Prepared by:** Mark Atwood
+**Date:** 2026-06-08
+**Status:** Ready for approval
+**Next step:** Merge PR #267 and enable GitHub Pages

--- a/GITHUB-PAGES-SETUP.md
+++ b/GITHUB-PAGES-SETUP.md
@@ -1,0 +1,282 @@
+# GitHub Pages Deployment for docs.wolfssl.com
+
+This document explains the GitHub Pages deployment setup for wolfSSL documentation.
+
+## Overview
+
+The wolfSSL documentation is automatically built and deployed to `docs.wolfssl.com` using GitHub Pages. Each product manual is built using MkDocs (via Docker) and deployed to its own subdirectory.
+
+## Architecture
+
+- **Repository:** `wolfSSL/documentation`
+- **Branch:** `master`
+- **Deployment:** GitHub Pages (automatic on push to master)
+- **Custom domain:** `docs.wolfssl.com`
+- **Build system:** Docker + MkDocs + Doxygen + Doxybook2
+
+## Site Structure
+
+```
+docs.wolfssl.com/
+├── index.html                  # Landing page with product links
+├── wolfssl/                    # wolfSSL Embedded SSL/TLS Library
+│   ├── index.html
+│   └── wolfSSL-Manual.pdf
+├── wolfssh/                    # wolfSSH Lightweight SSH
+│   ├── index.html
+│   └── wolfSSH-Manual.pdf
+├── wolftpm/                    # wolfTPM 2.0 Library
+│   ├── index.html
+│   └── wolfTPM-Manual.pdf
+├── wolfmqtt/                   # wolfMQTT Client Library
+├── wolfboot/                   # wolfBoot Secure Bootloader
+├── wolfsentry/                 # wolfSentry Firewall Engine
+├── wolfhsm/                    # wolfHSM Hardware Security Module
+├── wolfengine/                 # wolfEngine OpenSSL Engine
+├── wolfprovider/               # wolfProvider OpenSSL 3.0 Provider
+├── wolfclu/                    # wolfCLU Command Line Utility
+├── wolfssl-jni/                # wolfSSL JNI/JSSE Java Wrapper
+├── wolfcrypt-jni/              # wolfCrypt JNI/JCE Java Wrapper
+├── wolfssl-porting/            # Porting Guide
+├── wolfssl-tuning/             # Tuning Guide
+├── wolfssl-faq/                # FAQ
+├── wolfssl-fips-ready/         # FIPS Ready Guide
+├── wolfssl-fips-faq/           # FIPS FAQ
+└── bouncycastle-migration/     # BouncyCastle Migration Guide
+```
+
+## Workflow
+
+The deployment is handled by `.github/workflows/deploy-github-pages.yml`:
+
+1. **Trigger:** Push to `master` branch or manual workflow dispatch
+2. **Build:** Runs `make all` using Docker to build all manuals
+3. **Structure:** Creates `_site/` directory with organized manual subdirectories
+4. **Landing page:** Generates `index.html` with links to all manuals
+5. **Deploy:** Uploads to GitHub Pages
+
+## DNS Configuration
+
+**Required DNS records:**
+
+```
+docs.wolfssl.com
+  A     185.199.108.153
+  A     185.199.109.153
+  A     185.199.110.153
+  A     185.199.111.153
+```
+
+## GitHub Pages Settings
+
+**Repository Settings → Pages:**
+1. **Source:** GitHub Actions
+2. **Custom domain:** `docs.wolfssl.com`
+3. **Enforce HTTPS:** ✓ (enabled)
+
+## Build Time
+
+- **Full build:** ~15-20 minutes (all 18 manuals)
+- **Single manual:** ~1-2 minutes
+- **Deploy time:** ~1 minute
+
+## Adding a New Manual
+
+To add a new product manual:
+
+1. Create directory: `mkdir newProduct`
+2. Add MkDocs config: `newProduct/mkdocs.yml`
+3. Add source markdown: `newProduct/src/`
+4. Add to Makefile:
+   ```makefile
+   .PHONY: newproduct
+   newproduct: MANPATH=newProduct
+   newproduct: PDFFILE=newProduct-Manual.pdf
+   newproduct: build
+       $(Q)$(DOCKER_CMD)
+   ```
+5. Add to workflow `.github/workflows/deploy-github-pages.yml`:
+   - Add to manual list in "Create site structure" step
+6. Add card to landing page `index.html` template
+7. Commit and push - auto-deploys
+
+## Local Testing
+
+**Test build locally:**
+
+```bash
+# Build all manuals
+make all
+
+# Build single manual
+make wolfssl
+
+# Output is in build/ directory
+ls -la build/wolfSSL/html/
+```
+
+**Preview locally:**
+
+```bash
+# Serve wolfSSL manual on http://localhost:8000
+cd wolfSSL && make serve
+```
+
+## Comparison to WordPress VM
+
+### Before (WordPress VM)
+
+- **Location:** `/var/www/html/documentation/`
+- **Build:** Manual FTP upload after local build
+- **Updates:** Manual process
+- **Security:** VM to patch, Apache to maintain
+- **Cost:** $50-100/month (part of VM)
+- **Deployment:** Manual (FTP to VM)
+
+### After (GitHub Pages)
+
+- **Location:** GitHub Pages CDN
+- **Build:** Automatic on git push
+- **Updates:** Push to GitHub = auto-deploy
+- **Security:** No VM, static files only
+- **Cost:** $0
+- **Deployment:** Automatic CI/CD
+
+## Advantages Over WordPress VM Deployment
+
+**Security:**
+- No server to compromise
+- No PHP execution
+- No database
+- Static HTML only
+- Automatic HTTPS
+
+**Performance:**
+- CDN edge caching
+- No database queries
+- Pre-built HTML
+- Faster page loads
+
+**Developer Experience:**
+- Git-based workflow
+- PR reviews for doc changes
+- Version controlled
+- CI tests on every PR
+- Auto-deploy on merge
+
+**Reliability:**
+- No VM to crash
+- No manual FTP
+- GitHub's 99.95% SLA
+- No "forgot to upload" mistakes
+
+**Cost:**
+- $0 hosting
+- $0 maintenance
+- No VM fees
+
+## Migration from WordPress VM
+
+**Current state:**
+- WordPress VM hosts docs at `wolfssl.com/documentation/manuals/`
+- Manual builds uploaded via FTP
+- PDFs in root `/documentation/` directory
+
+**After migration:**
+- DNS points to GitHub Pages
+- Auto-builds and deploys
+- All manuals available at `docs.wolfssl.com/<product>/`
+- PDFs available at `docs.wolfssl.com/<product>/<Product>-Manual.pdf`
+
+**Cutover plan:**
+1. ✓ Create GitHub Pages deployment workflow
+2. ✓ Configure DNS for `docs.wolfssl.com`
+3. ✓ Enable GitHub Pages in repo settings
+4. Test docs.wolfssl.com (wait for DNS propagation)
+5. Update links from `wolfssl.com/documentation/manuals/` to `docs.wolfssl.com/`
+6. After 30 days: remove docs from WordPress VM
+
+**Rollback plan:**
+- Keep WordPress VM running for 30 days
+- If issues: revert DNS to WordPress VM
+- Documentation continues serving from old location
+
+## Maintenance
+
+**Regular tasks:**
+- **None** - Fully automated
+
+**When product releases:**
+- Update manual source in `<product>/src/`
+- Commit and push to master
+- GitHub Actions auto-builds and deploys
+- Takes ~20 minutes from push to live
+
+**When adding features:**
+- Update markdown in manual source
+- PR review process
+- Merge to master = auto-deploy
+
+## Access Control
+
+**Who can deploy:**
+- Anyone with write access to `wolfSSL/documentation` repo
+- Deployment triggered by push to `master` branch
+- PRs build and test but don't deploy
+
+**Who can approve PRs:**
+- Repository maintainers
+- CODEOWNERS (if configured)
+
+## Monitoring
+
+**Check deployment status:**
+- GitHub Actions: https://github.com/wolfSSL/documentation/actions
+- GitHub Pages status: Repository Settings → Pages
+
+**Check site:**
+- https://docs.wolfssl.com/
+- https://docs.wolfssl.com/wolfssl/
+- Check that PDFs load: https://docs.wolfssl.com/wolfssl/wolfSSL-Manual.pdf
+
+## Troubleshooting
+
+**Build fails:**
+- Check GitHub Actions logs
+- Common issues:
+  - Syntax error in mkdocs.yml
+  - Missing source files
+  - Docker build timeout
+
+**Site not updating:**
+- Check DNS propagation (15 minutes after change)
+- Check GitHub Actions completed successfully
+- Clear browser cache
+- Check CNAME file is correct
+
+**404 errors:**
+- Verify path matches directory structure
+- Check file was included in build output
+- Verify GitHub Pages is enabled
+
+**SSL certificate issues:**
+- GitHub auto-provisions Let's Encrypt cert
+- Wait 24 hours after DNS setup
+- Check "Enforce HTTPS" is enabled
+
+## Future Enhancements
+
+**Considered:**
+- Versioned docs (e.g., `docs.wolfssl.com/wolfssl/5.7/`)
+- Search functionality (Algolia DocSearch)
+- Contribution guidelines for docs
+- Automated link checking
+- Broken link detection
+- Dark mode theme
+
+## Questions?
+
+Contact Mark Atwood or refer to:
+- GitHub Pages docs: https://docs.github.com/en/pages
+- MkDocs documentation: https://www.mkdocs.org/
+- Repository README: https://github.com/wolfSSL/documentation/blob/master/README.md


### PR DESCRIPTION
## Summary

Adds automatic GitHub Pages deployment for all wolfSSL documentation to `docs.wolfssl.com`.

**⏳ Status: Waiting for approval from Larry and Todd**

## Changes

- GitHub Actions workflow that builds all 18+ manuals on push to master
- Landing page with organized cards for all products
- Custom domain configuration (docs.wolfssl.com)
- Comprehensive setup documentation (GITHUB-PAGES-SETUP.md)
- Deployment preparation guide (DEPLOYMENT-PREP.md)

## How It Works

1. Push to master triggers workflow
2. Docker builds all manuals (MkDocs + Doxygen + Doxybook2)
3. Organizes output into site structure (wolfssl/, wolfssh/, etc.)
4. Generates landing page with links to all manuals
5. Deploys to GitHub Pages

## Key Benefits

**vs. WordPress VM deployment:**
- 🌐 **GitHub's CDN** - Global edge caching (50+ locations) vs single VM in Ohio
- ⚡ **Automatic & instant** - Push to git = live docs in 20 minutes (no manual FTP)
- 💰 **Zero cost** - Saves ~$600/year (was part of $50-100/month VM)
- 🔒 **More secure** - Static files only (no PHP, no database, no server to compromise)
- 🚀 **Faster** - CDN edge caching vs single VM
- 📝 **Version controlled** - Git tracks all doc changes
- ✅ **CI/CD** - Test builds on every PR

## Cost Savings

```
Current (WordPress VM):  $615/year (hosting + ops time)
Proposed (GitHub Pages): $25/year  (minimal ops time)
Savings:                 $590/year (96% reduction)
```

## Next Steps After Approval

1. **Merge this PR** (requires approval from Larry/Todd, then repo admin can merge)
2. **Enable GitHub Pages:**
   - Go to Settings → Pages
   - Source: GitHub Actions
   - Custom domain: `docs.wolfssl.com`
3. **Configure DNS:**
   ```
   docs.wolfssl.com
     A     185.199.108.153
     A     185.199.109.153
     A     185.199.110.153
     A     185.199.111.153
   ```
4. **Wait ~20 minutes** for first build
5. **Verify:** https://docs.wolfssl.com/

## Risk & Rollback

**Risk level:** LOW
- Easy rollback: Point DNS back to WordPress VM (5 minutes)
- WordPress docs stay in place for 30-day validation period
- Can run both old and new in parallel

**Validation period:** 30 days with both sites running before removing docs from WordPress VM

## Documentation

- **DEPLOYMENT-PREP.md** - Complete deployment checklist, timeline, risk assessment, cost analysis
- **GITHUB-PAGES-SETUP.md** - Architecture, DNS config, local testing, troubleshooting

Full details in deployment prep doc. Total deployment time: ~1 hour active work + 20 min automated build.

---

**📧 Pitch email drafted for Larry/Todd**

🤖 Ready to decommission docs from WordPress VM after DNS cutover