### PR TITLE
fix: correct brand color to official Pantone 7466 U

### DIFF
--- a/common/skin.css
+++ b/common/skin.css
@@ -1,29 +1,35 @@
+/* wolfSSL Brand Colors
+ * Primary Teal: #00B2A9 (PANTONE 7466 U)
+ * CMYK: 70/0/23/0 (from 2012 original logo)
+ * Previous incorrect value: #1fbeca
+ */
+
 .md-header{
     background-color: #fff;
 }
 
 .md-ellipsis{
-    color: #1fbeca;
+    color: #00B2A9;
     font-size: 1.1rem;
 }
 
 .md-ellipsis-nav {
     margin-right: 3%;
-    color: #1fbeca;
+    color: #00B2A9;
     font-size: 16px;
     width: 450px;
 }
 
 .md-ellipsis-nav a{
     color:#fff;
-    background-color: #1fbeca;
+    background-color: #00B2A9;
     padding: 6px;
     border-radius: 3.5px;
     margin-left: 3px;
 }
 
 .md-ellipsis-nav a:hover{
-    color: #1fbeca;
+    color: #00B2A9;
     background-color: #000;
 }
 
@@ -53,11 +59,11 @@
 }
 
 .md-nav__link:is(:focus, :hover){
-    color: #1fbeca;
+    color: #00B2A9;
 }
 
 .md-nav__item .md-nav__link--active {
-    color: #1fbeca;
+    color: #00B2A9;
 }
 
 .md-header__button.md-logo :is(img, svg){
@@ -70,7 +76,7 @@
 }
 
 .md-typeset a:hover {
-     color: #1fbeca;
+     color: #00B2A9;
 }
 
 .md-footer {
@@ -79,7 +85,7 @@
 }
 
 .md-icon svg {
-    fill: #1fbeca;
+    fill: #00B2A9;
 }
 
 .md-footer-meta {

--- a/wolfSSH/src-ja/skin.css
+++ b/wolfSSH/src-ja/skin.css
@@ -1,29 +1,34 @@
+/* wolfSSL Brand Colors
+ * Primary Teal: #00B2A9 (PANTONE 7466 U)
+ * CMYK: 70/0/23/0 (from 2012 original logo)
+ * Previous incorrect value: #1fbeca
+ */
 .md-header{
     background-color: #fff;
 }
 
 .md-ellipsis{
-    color: #1fbeca;
+    color: #00B2A9;
     font-size: 1.1rem;
 }
 
 .md-ellipsis-nav {
     margin-right: 3%;
-    color: #1fbeca;
+    color: #00B2A9;
     font-size: 16px;
     width: 450px;
 }
 
 .md-ellipsis-nav a{
     color:#fff;
-    background-color: #1fbeca;
+    background-color: #00B2A9;
     padding: 6px;
     border-radius: 3.5px;
     margin-left: 3px;
 }
 
 .md-ellipsis-nav a:hover{
-    color: #1fbeca;
+    color: #00B2A9;
     background-color: #000;
 }
 
@@ -53,11 +58,11 @@
 }
 
 .md-nav__link:is(:focus, :hover){
-    color: #1fbeca;
+    color: #00B2A9;
 }
 
 .md-nav__item .md-nav__link--active {
-    color: #1fbeca;
+    color: #00B2A9;
 }
 
 .md-header__button.md-logo :is(img, svg){
@@ -70,7 +75,7 @@
 }
 
 .md-typeset a:hover {
-     color: #1fbeca;
+     color: #00B2A9;
 }
 
 .md-footer {
@@ -79,7 +84,7 @@
 }
 
 .md-icon svg {
-    fill: #1fbeca;
+    fill: #00B2A9;
 }
 
 .md-footer-meta {

--- a/wolfSSH/src/skin.css
+++ b/wolfSSH/src/skin.css
@@ -1,29 +1,34 @@
+/* wolfSSL Brand Colors
+ * Primary Teal: #00B2A9 (PANTONE 7466 U)
+ * CMYK: 70/0/23/0 (from 2012 original logo)
+ * Previous incorrect value: #1fbeca
+ */
 .md-header{
     background-color: #fff;
 }
 
 .md-ellipsis{
-    color: #1fbeca;
+    color: #00B2A9;
     font-size: 1.1rem;
 }
 
 .md-ellipsis-nav {
     margin-right: 3%;
-    color: #1fbeca;
+    color: #00B2A9;
     font-size: 16px;
     width: 450px;
 }
 
 .md-ellipsis-nav a{
     color:#fff;
-    background-color: #1fbeca;
+    background-color: #00B2A9;
     padding: 6px;
     border-radius: 3.5px;
     margin-left: 3px;
 }
 
 .md-ellipsis-nav a:hover{
-    color: #1fbeca;
+    color: #00B2A9;
     background-color: #000;
 }
 
@@ -53,11 +58,11 @@
 }
 
 .md-nav__link:is(:focus, :hover){
-    color: #1fbeca;
+    color: #00B2A9;
 }
 
 .md-nav__item .md-nav__link--active {
-    color: #1fbeca;
+    color: #00B2A9;
 }
 
 .md-header__button.md-logo :is(img, svg){
@@ -70,7 +75,7 @@
 }
 
 .md-typeset a:hover {
-     color: #1fbeca;
+     color: #00B2A9;
 }
 
 .md-footer {
@@ -79,7 +84,7 @@
 }
 
 .md-icon svg {
-    fill: #1fbeca;
+    fill: #00B2A9;
 }
 
 .md-footer-meta {


### PR DESCRIPTION
## Summary

Updates the primary teal color from `#1fbeca` to `#00B2A9` across all MkDocs skin files to match the official **PANTONE 7466 U** specification from the original 2012 logo design.

## Changes

- **common/skin.css** - Shared by all product manuals
- **wolfSSH/src/skin.css** - English documentation
- **wolfSSH/src-ja/skin.css** - Japanese documentation

All instances of `#1fbeca` replaced with `#00B2A9` (8-11 occurrences per file).

## Brand Color Documentation

Added header comments to all skin files documenting:
- **PANTONE 7466 U** (Uncoated stock)
- **CMYK**: 70/0/23/0 (from 2012 logo file metadata)
- **sRGB**: #00B2A9
- Note about the previous incorrect value

## Background

The incorrect `#1fbeca` color has been used across wolfSSL web properties for years. The official Pantone spec was discovered in `wolfssl-logo-2012.eps` file metadata (created December 14, 2012 by designer Laura).

**Color comparison:**
- Old (incorrect): `#1fbeca` - RGB(31, 190, 202) - too cyan/blue
- New (correct): `#00B2A9` - RGB(0, 178, 169) - proper teal, matches Pantone 7466 U

## Related Changes

- Blog (posts.wolfssl.com): Already updated with wide-gamut display support
- Marketing site: TBD
- API docs (Doxygen): TBD

## Testing

Visual regression testing recommended:
- Build all manuals locally with `make all`
- Verify teal accent colors appear consistent
- Check navigation links, hover states, icons

## Draft Status

Marked as **draft** to coordinate timing with:
1. docs.wolfssl.com deployment (PR #267)
2. Other brand consistency updates
3. Marketing approval if needed

Ready to merge once docs site goes live.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)