### PR TITLE
Fix broken struct/class API pages and doc links

### DIFF
--- a/wolfHSM/Makefile
+++ b/wolfHSM/Makefile
@@ -100,6 +100,12 @@ pdf-setup: wolfhsm-update builddir
 .PHONY: html-prep
 html-prep: api
 	$(Q)cp -a api/md/*8h* build/html/
+	$(Q)cp -a api/md/Classes build/html/
+	$(Q)perl -i -pe 's#\]\(/Classes/#](#g' build/html/Classes/*.md
+	$(Q)perl -i -pe "s/Classes\///g" build/html/Classes/*.md
+	$(Q)perl -i -pe 's#\]\(/#](../#g' build/html/Classes/*.md
+	$(Q)perl -i -pe 's#\]\(/#](#g' build/html/*8h*
+	$(Q)perl -i -pe "s/(\]\([^)#]*#[a-z]+-)([^)]+?)(\))/\$$1.(\$$2=~tr#-#_#r).\$$3/ge" build/html/*8h* build/html/Classes/*.md
 
 	$(Q)perl -i -pe "s/\/group_/group_/g" build/html/group* build/html/*8h*
 	$(Q)perl -i -pe "s/dox_comments\/header_files\///" build/html/*8h*

--- a/wolfHSM/doxybook.cfg
+++ b/wolfHSM/doxybook.cfg
@@ -12,6 +12,7 @@
   "folderGroupsName": "",
   "folderFilesName": "",
   "foldersToGenerate": [
+    "classes",
     "modules",
     "files"
   ]

--- a/wolfMQTT/Makefile
+++ b/wolfMQTT/Makefile
@@ -40,14 +40,15 @@ api: wolfmqtt-update
 .PHONY: html-prep
 html-prep: api
 	$(Q)cp -a api/md/*8h* build/html/
+	$(Q)cp -a api/md/Classes build/html/
 	$(Q)rm -rf build/html/chapter05.md
-	$(Q)perl -i -pe "s/Classes\///g" build/html/*8h*
-	$(Q)perl -i -pe "s/(?<=md\#function\-)(.*)(?=\))/\$$1=~s#-#_#gr/ge"   build/html/*8h*
-	$(Q)perl -i -pe "s/(?<=md\#typedef\-)(.*)(?=\))/\$$1=~s#-#_#gr/ge"   build/html/*8h*
-	$(Q)perl -i -pe "s/(?<=md\#enum\-)(.*)(?=\))/\$$1=~s#-#_#gr/ge"   build/html/*8h*
-	$(Q)perl -i -pe "s/\\\\discussion//g" build/html/*8h*
-	$(Q)perl -i -pe "s/\/mqtt_/mqtt_/g" build/html/*8h*
-	$(Q)perl -i -pe "s/dox_comments\/header_files\///" build/html/*8h*
+	$(Q)perl -i -pe "s/\\\\discussion//g" build/html/*8h* build/html/Classes/*.md
+	$(Q)perl -i -pe "s/dox_comments\/header_files\///" build/html/*8h* build/html/Classes/*.md
+	$(Q)perl -i -pe 's#\]\(/#](#g' build/html/*8h*
+	$(Q)perl -i -pe 's#\]\(/Classes/#](#g' build/html/Classes/*.md
+	$(Q)perl -i -pe "s/Classes\///g" build/html/Classes/*.md
+	$(Q)perl -i -pe 's#\]\(/#](../#g' build/html/Classes/*.md
+	$(Q)perl -i -pe "s/(\]\([^)#]*#[a-z]+-)([^)]+?)(\))/\$$1.(\$$2=~tr#-#_#r).\$$3/ge" build/html/*8h* build/html/Classes/*.md
 
 # Set input format to gfm to fix issues with converted API docs
 # Regexes:

--- a/wolfMQTT/doxybook.cfg
+++ b/wolfMQTT/doxybook.cfg
@@ -12,6 +12,7 @@
   "folderGroupsName": "",
   "folderFilesName": "",
   "foldersToGenerate": [
+    "classes",
     "modules",
     "files"
   ]

--- a/wolfSSL/Makefile
+++ b/wolfSSL/Makefile
@@ -67,6 +67,7 @@ html-prep: api
 	$(Q)rm -f build/html/appendix01.md build/html/appendix02.md build/html/appendix03.md
 	$(Q)perl -i -pe "s/(?<=md\#function\-)(.*)(?=\))/\$$1=~s#-#_#gr/ge" build/html/group* build/html/*8h*
 	$(Q)perl -i -pe "s/\/group_/group_/g" build/html/group* build/html/*8h*
+	$(Q)perl -i -pe 's#\]\(/#](#g' build/html/group* build/html/*8h*
 	$(Q)perl -i -pe "s/dox_comments\/$(HEADER_FILES)\///" build/html/*8h*
 
 # Set input format to gfm to fix issues with converted API docs

--- a/wolfTPM/Makefile
+++ b/wolfTPM/Makefile
@@ -48,6 +48,12 @@ html-prep: api
   else
 	$(Q)cp -a api/md/group* build/html/
 	$(Q)cp -a api/md/*8h* build/html/
+	$(Q)cp -a api/md/Classes build/html/
+	$(Q)perl -i -pe 's#\]\(/Classes/#](#g' build/html/Classes/*.md
+	$(Q)perl -i -pe "s/Classes\///g" build/html/Classes/*.md
+	$(Q)perl -i -pe 's#\]\(/#](../#g' build/html/Classes/*.md
+	$(Q)perl -i -pe 's#\]\(/#](#g' build/html/group* build/html/*8h*
+	$(Q)perl -i -pe "s/(\]\([^)#]*#[a-z]+-)([^)]+?)(\))/\$$1.(\$$2=~tr#-#_#r).\$$3/ge" build/html/group* build/html/*8h* build/html/Classes/*.md
   endif
 
 	$(Q)rm -rf build/html/chapter05.md

--- a/wolfTPM/doxybook.cfg
+++ b/wolfTPM/doxybook.cfg
@@ -12,6 +12,7 @@
   "folderGroupsName": "",
   "folderFilesName": "",
   "foldersToGenerate": [
+    "classes",
     "modules",
     "files"
   ]


### PR DESCRIPTION
This PR fixes broken links in the generated API documentation for wolfSSL, wolfMQTT, wolfTPM, and wolfHSM.

  - **Struct/class pages were never generated**: `doxybook.cfg` omitted `"classes"` from `foldersToGenerate`, so links to
  struct/class pages 404'd.
  - **Intra-page and struct links didn't resolve**: the Functions table (and struct references) used doxybook's dash anchors
  and leading-slash `.md` paths, which mkdocs doesn't rewrite to the built `.html` pages.

## Changes

  - Add `"classes"` to `foldersToGenerate` (wolfMQTT, wolfTPM, wolfHSM).
  - In `html-prep`: copy `Classes/` pages into the site, strip leading slashes, and convert dash anchors to the underscore ids mkdocs generates.
  - Convert wolfMQTT to the `Classes/` subfolder layout for consistency.

Found when analyzing web server 404 logs.